### PR TITLE
BUILD-264: Refresh-Resources Mode and Configurable Namespaces

### DIFF
--- a/deploy/csi-hostpath-plugin.yaml
+++ b/deploy/csi-hostpath-plugin.yaml
@@ -70,6 +70,30 @@ spec:
             - "--v=4"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            - --ignorenamespace=openshift-machine-api
+            - --ignorenamespace=openshift-kube-apiserver
+            - --ignorenamespace=openshift-kube-apiserver-operator
+            - --ignorenamespace=openshift-kube-scheduler
+            - --ignorenamespace=openshift-kube-controller-manager
+            - --ignorenamespace=openshift-kube-controller-manager-operator
+            - --ignorenamespace=openshift-kube-scheduler-operator
+            - --ignorenamespace=openshift-console-operator
+            - --ignorenamespace=openshift-controller-manager
+            - --ignorenamespace=openshift-controller-manager-operator
+            - --ignorenamespace=openshift-cloud-credential-operator
+            - --ignorenamespace=openshift-authentication-operator
+            - --ignorenamespace=openshift-service-ca
+            - --ignorenamespace=openshift-kube-storage-version-migrator-operator
+            - --ignorenamespace=openshift-config-operator
+            - --ignorenamespace=openshift-etcd-operator
+            - --ignorenamespace=openshift-apiserver-operator
+            - --ignorenamespace=openshift-cluster-csi-drivers
+            - --ignorenamespace=openshift-cluster-storage-operator
+            - --ignorenamespace=openshift-cluster-version
+            - --ignorenamespace=openshift-image-registry
+            - --ignorenamespace=openshift-machine-config-operator
+            - --ignorenamespace=openshift-sdn
+            - --ignorenamespace=openshift-service-ca-operator
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/docs/content-update-details.md
+++ b/docs/content-update-details.md
@@ -2,7 +2,7 @@
 
 ### Excluded OCP namespaces
 
-The current list of namespaces excluded from the controller's watches:
+The current list of namespaces excluded by default from the controller's watches:
 
 - kube-system
 - openshift-machine-api
@@ -30,7 +30,14 @@ The current list of namespaces excluded from the controller's watches:
 - openshift-sdn
 - openshift-service-ca-operator
 
-The list is not yet configurable, but most likely will become so as the project's lifecycle progresses.
+The list is configurable by informing `--ignorenamespace` to the `hostpath` plugin instance. The
+plugin can also be configured with `--refreshresources` flag, which makes the controller keep a warm
+cache of `ConfigMap` and `Secret` objects, and as they change the controller will follow the updates.
+
+When `--refreshresources` is disabled (i.e. `--refreshresources=false`), the controller will read the
+backing-resource (`.spec.backingResource`) just before mounting the volume instead of keeping a warm
+cache. Additionally, every volume mount will be always read-only preventing tampering with the data
+provided by this CSI driver.
 
 Allowing the disabling processing of updates, or switching the default for the system as not dealing with
 updates, but then allowing for opting into updates, is also under consideration.

--- a/pkg/cache/common.go
+++ b/pkg/cache/common.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,15 @@ func GetKey(o interface{}) string {
 
 func BuildKey(namespace, name string) string {
 	return namespace + ":" + name
+}
+
+// SplitKey splits the shared-data-key into namespace and name.
+func SplitKey(key string) (string, string, error) {
+	s := strings.Split(key, ":")
+	if len(s) != 2 || s[0] == "" || s[1] == "" {
+		return "", "", fmt.Errorf("unable to split key '%s' into namespace and name", key)
+	}
+	return s[0], s[1], nil
 }
 
 func buildCallbackMap(key, value interface{}) *sync.Map {

--- a/pkg/hostpath/nodeserver_test.go
+++ b/pkg/hostpath/nodeserver_test.go
@@ -44,7 +44,7 @@ func testNodeServer(testName string) (*nodeServer, string, string, error) {
 	if strings.Contains(testName, "/") {
 		testName = strings.Split(testName, "/")[0]
 	}
-	hp, tmpDir, volPathTmpDir, err := testHostPathDriver(testName)
+	hp, tmpDir, volPathTmpDir, err := testHostPathDriver(testName, nil)
 	if err != nil {
 		return nil, "", "", err
 	}


### PR DESCRIPTION
This pull-request adds two more flags on the operator (controller) part of the CSI Driver. And modifies the test infrastructure to be able to deploy with different arguments.

### Flags

Using `--refreshresources=false` (default's `true`) flag the operator will only watch `Share` resources, and will read the actual backing resource object just before mounting the volume. Previously it use to watch over most of the `ConfigMap` and `Secret` resources. By using this flag the operator will consume less resources, and won't watch for eventual resources modifications.

Additionally, the list of ignored namespaces can be edited using `--ignorenamespace`. The original list of ignored namespaces is kept by default.

### E2E

A new target is added, `test-e2e-no-refreshresources` which deploys the operator using this mode and runs the configured test-suite against. For instance:

```bash
make test-e2e-no-refreshresources DRIVER_IMAGE="..." NODE_REGISTRAR_IMAGE="..."
```