### PR TITLE
make deploy must call make crd until our crd api is vendored into openshift-apiserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: ## Run unit tests. Example: make test
 	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go test $(GOFLAGS) -count 1 ./cmd/... ./pkg/...
 .PHONY: test
 
-deploy: ## Deploy the local build of the shared resource csi driver into the current cluster
+deploy: crd ## Deploy the local build of the shared resource csi driver into the current cluster
 	NODE_REGISTRAR_IMAGE=$(NODE_REGISTRAR_IMAGE) DRIVER_IMAGE=$(DRIVER_IMAGE) ./deploy/deploy.sh $(DEPLOY_MODE)
 .PHONY: deploy
 


### PR DESCRIPTION
discovered this while working on some feedback from Jan

/assign @coreydaley 

@akram FYI

once @coreydaley 's changes are vendored into openshift/openshift-apiserver we should be able to undo this 