### PR TITLE
WIP: Use hostpath volume for driver's data

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,17 @@
+
+oc login https://api.ci.l2s4.p1.openshiftapps.com:6443
+oc registry login
+
+podman login quay.io
+
+make build-image -e REGISTRY=quay.io -e REPOSITORY=akram
+make deploy -e DRIVER_IMAGE=quay.io/akram/origin-csi-driver-shared-resource:latest
+
+oc create namespace my-csi-app-namespace 
+oc create cm -n my-csi-app-namespace my-other-share --from-file=cm/
+
+
+oc get pods -n openshift-cluster-csi-drivers  -o wide
+
+oc apply -f examples/
+

--- a/examples/02-csi-share.yaml
+++ b/examples/02-csi-share.yaml
@@ -4,5 +4,5 @@ metadata:
   name: my-share
 spec:
   configMapRef:
-    name: openshift-install
-    namespace: openshift-config
+    name: my-other-share
+    namespace: my-csi-app-namespace

--- a/examples/csi-app.yaml
+++ b/examples/csi-app.yaml
@@ -21,7 +21,7 @@ spec:
             touch /data/foo
             ls -laZ /data
             echo "calling sleep"
-            sleep 120
+            sleep 10
           done
   volumes:
     - name: my-csi-volume

--- a/examples/csi-app.yaml
+++ b/examples/csi-app.yaml
@@ -7,7 +7,7 @@ spec:
   serviceAccountName: default
   containers:
     - name: my-frontend
-      image: quay.io/quay/busybox
+      image: registry.access.redhat.com/ubi8/ubi
       volumeMounts:
         - mountPath: "/data"
           name: my-csi-volume
@@ -17,16 +17,16 @@ spec:
         - |
           while true
           do
-            ls -la /data
+            ls -laZ /data
             touch /data/foo
-            ls -la /data
+            ls -laZ /data
             echo "calling sleep"
             sleep 120
           done
   volumes:
     - name: my-csi-volume
       csi:
-        #readOnly: true
+        readOnly: true
         driver: csi.sharedresource.openshift.io
         volumeAttributes:
           sharedConfigMap: my-share

--- a/pkg/hostpath/constants.go
+++ b/pkg/hostpath/constants.go
@@ -17,7 +17,8 @@ const (
 	CSIEphemeral                       = "csi.storage.k8s.io/ephemeral"
 	SharedConfigMapShareKey            = "sharedConfigMap"
 	SharedSecretShareKey               = "sharedSecret"
-	//anchorDir                          = "anchor-dir"
-	bindDir                            = "bind-dir"
+	AnchorDir                          = "anchor-dir"
+	TmpFsType                          = "tmpfs"
+	BindDir                            = "bind-dir"
 	mountAccess             accessType = iota
 )

--- a/pkg/hostpath/constants.go
+++ b/pkg/hostpath/constants.go
@@ -17,7 +17,7 @@ const (
 	CSIEphemeral                       = "csi.storage.k8s.io/ephemeral"
 	SharedConfigMapShareKey            = "sharedConfigMap"
 	SharedSecretShareKey               = "sharedSecret"
-	anchorDir                          = "anchor-dir"
+	//anchorDir                          = "anchor-dir"
 	bindDir                            = "bind-dir"
 	mountAccess             accessType = iota
 )

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -69,7 +69,7 @@ const (
 	// Directory where data for volumes are persisted.
 	// This is ephemeral to facilitate our per-pod, tmpfs,
 	// no bind mount, approach.
-	DataRoot = "/csi-data-dir"
+	DataRoot = "/run/csi-data-dir"
 
 	// Directory where we persist `hostPathVolumes`
 	// This is a hostpath volume on the local node

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -175,7 +175,7 @@ func (hp *hostPath) Run() {
 // getVolumePath returns the canonical paths for hostpath volume
 func (hp *hostPath) getVolumePath(volID string, volCtx map[string]string) (string, string) {
 	podNamespace, podName, podUID, podSA := getPodDetails(volCtx)
-	return filepath.Join(hp.root, anchorDir, volID, podNamespace, podName, podUID, podSA), filepath.Join(hp.root, bindDir, volID, podNamespace, podName, podUID, podSA)
+	return filepath.Join(hp.root, volID, podNamespace, podName, podUID, podSA), filepath.Join(hp.root, bindDir, volID, podNamespace, podName, podUID, podSA)
 }
 
 func commonUpsertRanger(obj runtime.Object, podPath, filter string, key, value interface{}) error {

--- a/pkg/hostpath/hpv.go
+++ b/pkg/hostpath/hpv.go
@@ -37,7 +37,7 @@ type hostPathVolume struct {
 
 func CreateHPV(volID string) *hostPathVolume {
 	hpv := &hostPathVolume{VolID: volID, Lock: &sync.Mutex{}}
-	setHPV(volID, hpv)
+	setHostPathVolume(volID, hpv)
 	return hpv
 }
 

--- a/pkg/hostpath/mount.go
+++ b/pkg/hostpath/mount.go
@@ -52,15 +52,15 @@ type ReadWriteMany struct {
 
 func (m *ReadWriteMany) makeFSMounts(anchorDir, intermediateBindMountDir, kubeletTargetDir string, mounter mount.Interface) error {
 	options := []string{}
-	if err := mounter.Mount(anchorDir, kubeletTargetDir, "tmpfs", options); err != nil {
+	if err := mounter.Mount("GGM", kubeletTargetDir, "tmpfs", options); err != nil {
 		var errList strings.Builder
 		errList.WriteString(err.Error())
-		if rmErr := os.RemoveAll(anchorDir); rmErr != nil && !os.IsNotExist(rmErr) {
+		if rmErr := os.RemoveAll("GGM"); rmErr != nil && !os.IsNotExist(rmErr) {
 			errList.WriteString(fmt.Sprintf(" :%s", rmErr.Error()))
 		}
 
 		return status.Error(codes.Internal, fmt.Sprintf("failed to mount device: %s at %s: %s",
-			anchorDir,
+			"GGM",
 			kubeletTargetDir,
 			errList.String()))
 	}
@@ -94,15 +94,15 @@ type WriteOnceReadMany struct {
 func (m *WriteOnceReadMany) makeFSMounts(anchorDir, intermediateBindMountDir, kubeletTargetDir string, mounter mount.Interface) error {
 	options := []string{}
 
-	if err := mounter.Mount(anchorDir, intermediateBindMountDir, "tmpfs", options); err != nil {
+	if err := mounter.Mount("GGM", intermediateBindMountDir, "tmpfs", options); err != nil {
 		var errList strings.Builder
 		errList.WriteString(err.Error())
-		if rmErr := os.RemoveAll(anchorDir); rmErr != nil && !os.IsNotExist(rmErr) {
+		if rmErr := os.RemoveAll("GGM"); rmErr != nil && !os.IsNotExist(rmErr) {
 			errList.WriteString(fmt.Sprintf(" :%s", rmErr.Error()))
 		}
 
 		return status.Error(codes.Internal, fmt.Sprintf("failed to mount device: %s at %s: %s",
-			anchorDir,
+			"GGM",
 			intermediateBindMountDir,
 			errList.String()))
 	}

--- a/pkg/hostpath/mount.go
+++ b/pkg/hostpath/mount.go
@@ -63,7 +63,7 @@ func (m *ReadWriteMany) makeFSMounts(volumeRequest *csi.NodePublishVolumeRequest
 		}
 
 		return status.Error(codes.Internal, fmt.Sprintf("failed to mount device: %s at %s: %s",
-			AnchorDir,
+			anchorDir,
 			kubeletTargetDir,
 			errList.String()))
 	}
@@ -74,7 +74,7 @@ func (m *ReadWriteMany) removeFSMounts(intermediateBindMountDir, kubeletTargetDi
 	if err := mount.CleanupMountPoint(kubeletTargetDir, mounter, true); err != nil {
 		return err
 	}
-	if err := os.RemoveAll(AnchorDir); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(intermediateBindMountDir); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/test/e2e/disruptive_test.go
+++ b/test/e2e/disruptive_test.go
@@ -13,7 +13,7 @@ func TestBasicThenDriverRestartThenChangeShare(t *testing.T) {
 	testArgs := &framework.TestArgs{
 		T: t,
 	}
-	prep(testArgs)
+	TestBasicThenDriverRestartThenChangeShareWithReadOnlyMount(t)
 	framework.CreateTestNamespace(testArgs)
 	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
 	basicShareSetupAndVerification(testArgs)

--- a/test/e2e/disruptive_test.go
+++ b/test/e2e/disruptive_test.go
@@ -30,3 +30,27 @@ func TestBasicThenDriverRestartThenChangeShare(t *testing.T) {
 	testArgs.SearchString = "ca.crt"
 	framework.ExecPod(testArgs)
 }
+
+
+func TestBasicThenDriverRestartThenChangeShareWithReadOnlyMount(t *testing.T) {
+	testArgs := &framework.TestArgs{
+		T: t,
+	}
+	testArgs.ReadOnly = true
+	prep(testArgs)
+	framework.CreateTestNamespace(testArgs)
+	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
+	basicShareSetupAndVerification(testArgs)
+
+	t.Logf("%s: initiating csi driver restart", time.Now().String())
+	framework.RestartDaemonSet(testArgs)
+	t.Logf("%s: csi driver restart complete, check test pod", time.Now().String())
+	testArgs.TestDuration = 30 * time.Second
+	testArgs.SearchString = "invoker"
+	framework.ExecPod(testArgs)
+
+	t.Logf("%s: now changing share", time.Now().String())
+	framework.ChangeShare(testArgs)
+	testArgs.SearchString = "ca.crt"
+	framework.ExecPod(testArgs)
+}

--- a/test/e2e/normal_test.go
+++ b/test/e2e/normal_test.go
@@ -43,14 +43,14 @@ func coreTestBasicThenNoShareThenShare(testArgs *framework.TestArgs) {
 	testArgs.ShareToDeleteType = consts.ResourceReferenceTypeConfigMap
 	framework.DeleteShare(testArgs)
 	testArgs.TestDuration = 30 * time.Second
-	testArgs.SearchStringMissing = true
+	testArgs.EnsureStringIsAbsent = true
 	testArgs.SearchString = "invoker"
 	framework.ExecPod(testArgs)
 
 	testArgs.T.Logf("%s: adding share back for %s", time.Now().String(), testArgs.Name)
 
 	framework.CreateShare(testArgs)
-	testArgs.SearchStringMissing = false
+	testArgs.EnsureStringIsAbsent = false
 	testArgs.SearchString = "invoker"
 	framework.ExecPod(testArgs)
 }
@@ -133,7 +133,7 @@ func TestTwoSharesSeparateButInheritedMountPathsRemoveSubPath(t *testing.T) {
 	testArgs.SearchString = "invoker"
 	framework.ExecPod(testArgs)
 
-	testArgs.SearchStringMissing = true
+	testArgs.EnsureStringIsAbsent = true
 	testArgs.SearchString = ".dockerconfigjson"
 	framework.ExecPod(testArgs)
 }
@@ -154,7 +154,7 @@ func TestTwoSharesSeparateButInheritedMountPathsRemoveTopPath(t *testing.T) {
 	testArgs.SearchString = ".dockerconfigjson"
 	framework.ExecPod(testArgs)
 
-	testArgs.SearchStringMissing = true
+	testArgs.EnsureStringIsAbsent = true
 	testArgs.SearchString = "invoker"
 	framework.ExecPod(testArgs)
 }

--- a/test/e2e/slow_test.go
+++ b/test/e2e/slow_test.go
@@ -20,14 +20,14 @@ func TestBasicThenNoRBACThenRBAC(t *testing.T) {
 
 	framework.DeleteShareRelatedRBAC(testArgs)
 	t.Logf("%s: wait up to 10 minutes for examining pod %s since the controller does not currently watch all clusterroles and clusterrolebindings and reverse engineer which ones satisfied the SAR calls, so we wait for relist on shares", time.Now().String(), testArgs.Name)
-	testArgs.SearchStringMissing = true
+	testArgs.EnsureStringIsAbsent = true
 	testArgs.TestDuration = 10 * time.Minute
 	testArgs.SearchString = "invoker"
 	framework.ExecPod(testArgs)
 
 	framework.CreateShareRelatedRBAC(testArgs)
 	t.Logf("%s: wait up to 10 minutes for examining pod %s since the controller does not currently watch all clusterroles and clusterrolebindings and reverse engineer which ones satisfied the SAR calls, so we wait for relist on shares", time.Now().String(), testArgs.Name)
-	testArgs.SearchStringMissing = false
+	testArgs.EnsureStringIsAbsent = false
 	testArgs.SearchString = "invoker"
 	framework.ExecPod(testArgs)
 }

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -183,12 +183,12 @@ func ExecPod(t *TestArgs) {
 				t.T.Logf("%s: error with remote exec: %s, errOut: %s", time.Now().String(), err.Error(), errOut)
 				return false, nil
 			}
-			if !t.SearchStringMissing && !strings.Contains(out.String(), t.SearchString) {
-				t.T.Logf("%s: directory listing did not have expected output: missing: %v\nout: %s\nerr: %s\n", time.Now().String(), t.SearchStringMissing, out.String(), errOut.String())
+			if !t.EnsureStringIsAbsent && !strings.Contains(out.String(), t.SearchString) {
+				t.T.Logf("%s: directory listing must contain: '%v' but it doesn't\nout: %s\nerr: %s\n", time.Now().String(), t.SearchString, out.String(), errOut.String())
 				return false, nil
 			}
-			if t.SearchStringMissing && strings.Contains(out.String(), t.SearchString) {
-				t.T.Logf("%s: directory listing did not have expected output: missing: %v\nout: %s\nerr: %s\n", time.Now().String(), t.SearchStringMissing, out.String(), errOut.String())
+			if t.EnsureStringIsAbsent && strings.Contains(out.String(), t.SearchString) {
+				t.T.Logf("%s: directory listing should not contain: '%v' but it does\nout: %s\nerr: %s\n", time.Now().String(), t.SearchString, out.String(), errOut.String())
 				return false, nil
 			}
 			t.T.Logf("%s: final directory listing:\n%s", time.Now().String(), out.String())
@@ -199,7 +199,7 @@ func ExecPod(t *TestArgs) {
 		}
 	}
 
-	t.MessageString = fmt.Sprintf("directory listing search for %s with missing %v failed", t.SearchString, t.SearchStringMissing)
+	t.MessageString = fmt.Sprintf("directory listing search for %s with missing %v failed", t.SearchString, t.EnsureStringIsAbsent)
 	LogAndDebugTestError(t)
 }
 
@@ -273,22 +273,21 @@ func SearchCSIPods(t *TestArgs) {
 	}
 	err := wait.PollImmediate(pollInterval, t.TestDuration, func() (bool, error) {
 		dumpCSIPods(t)
-
-		if !t.SearchStringMissing && !strings.Contains(t.LogContent, t.SearchString) {
-			t.T.Logf("%s: csi pod listing did not have expected output: missing: %v\n", time.Now().String(), t.SearchStringMissing)
+		if !t.EnsureStringIsAbsent && !strings.Contains(t.LogContent, t.SearchString) {
+			t.T.Logf("%s: directory listing must contain: '%v' but it doesn't\nout: %s\nerr: %s\n", time.Now().String(), t.SearchString, t.LogContent)
 			return false, nil
 		}
-		if t.SearchStringMissing && strings.Contains(t.LogContent, t.SearchString) {
-			t.T.Logf("%s: directory listing did not have expected output: missing: %v\n", time.Now().String(), t.SearchStringMissing)
+		if t.EnsureStringIsAbsent && strings.Contains(t.LogContent, t.SearchString) {
+			t.T.Logf("%s: directory listing should not contain: '%v' but it does\nout: %s\nerr: %s\n", time.Now().String(), t.SearchString, t.LogContent)
 			return false, nil
 		}
-		t.T.Logf("%s: shared resource driver pods are good with search string criteria: missing: %v\n, string: %s\n", time.Now().String(), t.SearchStringMissing, t.SearchString)
+		t.T.Logf("%s: shared resource driver pods are good with search string criteria: must be absent: %v\n, string: %s\n", time.Now().String(), t.EnsureStringIsAbsent, t.SearchString)
 		return true, nil
 	})
 	if err == nil {
 		return
 	}
-	t.MessageString = fmt.Sprintf("%s: csi pod bad missing: %v\n, string: %s\n", time.Now().String(), t.SearchStringMissing, t.SearchString)
+	t.MessageString = fmt.Sprintf("%s: csi pod does not satisfy search criteria: string must be absent: %v\n, string: %s\n", time.Now().String(), t.EnsureStringIsAbsent, t.SearchString)
 	LogAndDebugTestError(t)
 }
 

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -48,7 +48,7 @@ func CreateTestPod(t *TestArgs) {
 			Containers: []corev1.Container{
 				{
 					Name:    containerName,
-					Image:   "quay.io/quay/busybox",
+					Image:   "registry.access.redhat.com/ubi8/ubi",
 					Command: []string{"sleep", "1000000"},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -172,7 +172,7 @@ func ExecPod(t *TestArgs) {
 		err := wait.PollImmediate(pollInterval, t.TestDuration, func() (bool, error) {
 			req := restClient.Post().Resource("pods").Namespace(t.Name).Name(t.Name).SubResource("exec").
 				Param("container", containerName).Param("stdout", "true").Param("stderr", "true").
-				Param("command", "ls").Param("command", "-laR").Param("command", startingPoint)
+				Param("command", "ls").Param("command", "-laRZ").Param("command", startingPoint)
 
 			out := &bytes.Buffer{}
 			errOut := &bytes.Buffer{}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -21,7 +21,7 @@ type TestArgs struct {
 	LogContent                         string
 	CurrentDriverContainerRestartCount map[string]int32
 	ShareToDeleteType                  consts.ResourceReferenceType
-	SearchStringMissing                bool
+	EnsureStringIsAbsent               bool
 	SecondShare                        bool
 	SecondShareSubDir                  bool
 	DaemonSetUp                        bool


### PR DESCRIPTION
This is supposed to fix the failure on restart of the CSI driver when using shared volumes backed by volumes stored on tmpfs.
