### PR TITLE
BUILD-256: clear out remaining local deploy; make no refresh resource test functional again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,14 @@ config: ## Overwrites the configuration ConfigMap with local settings
 	./hack/configmap.sh $(DEPLOY_MODE)
 .PHONY: config
 
-# overwrites the deployment mode variable to disable refresh-resources
-deploy-no-refreshresources: DEPLOY_MODE = "no-refreshresources"
-deploy-no-refreshresources: config
-
 test-e2e-no-deploy:
 	TEST_SUITE=$(TEST_SUITE) TEST_TIMEOUT=$(TEST_TIMEOUT) DAEMONSET_PODS=$(DAEMONSET_PODS) ./hack/test-e2e.sh
 .PHONY: test-e2e-no-deploy
 
 test-e2e: test-e2e-no-deploy
 
-test-e2e-no-refreshresources: deploy-no-refreshresources test-e2e-no-deploy
+test-e2e-no-refreshresources: TEST_SUITE = "norefresh"
+test-e2e-no-refreshresources: test-e2e
 
 test-e2e-slow: TEST_SUITE = "slow"
 test-e2e-slow: test-e2e

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	DefaultNamespace = "openshift-cluster-csi-drivers"
+	DefaultNamespace             = "openshift-cluster-csi-drivers"
+	DriverConfigurationConfigMap = "csi-driver-shared-resource-config"
+	DriverConfigurationDataKey   = "config.yaml"
 )
 
 var (

--- a/test/e2e/disruptive_test.go
+++ b/test/e2e/disruptive_test.go
@@ -3,9 +3,10 @@
 package e2e
 
 import (
-	"github.com/openshift/csi-driver-shared-resource/test/framework"
 	"testing"
 	"time"
+
+	"github.com/openshift/csi-driver-shared-resource/test/framework"
 )
 
 func TestBasicThenDriverRestartThenChangeShare(t *testing.T) {

--- a/test/e2e/norefresh_test.go
+++ b/test/e2e/norefresh_test.go
@@ -1,0 +1,32 @@
+// +build norefresh
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/csi-driver-shared-resource/test/framework"
+)
+
+func TestChangeRefreshConfigurationThenBasic(t *testing.T) {
+	testArgs := &framework.TestArgs{
+		T: t,
+	}
+	prep(testArgs)
+	framework.CreateTestNamespace(testArgs)
+	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
+
+	testArgs.CurrentDriverContainerRestartCount = framework.GetPodContainerRestartCount(testArgs)
+	framework.TurnOffRefreshResources(testArgs)
+	err := framework.WaitForPodContainerRestart(testArgs)
+	if err != nil {
+		testArgs.MessageString = fmt.Sprintf("hostpath container restart did not seem to occur")
+		framework.LogAndDebugTestError(testArgs)
+	}
+
+	testArgs.SearchString = "Refresh-Resources disabled"
+	framework.SearchCSIPods(testArgs)
+
+	basicShareSetupAndVerification(testArgs)
+}

--- a/test/framework/configmap.go
+++ b/test/framework/configmap.go
@@ -1,0 +1,99 @@
+package framework
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/csi-driver-shared-resource/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	noRefreshConfgYaml = `
+---
+ignoredNamespaces: 
+  - openshift-machine-api
+  - openshift-kube-apiserver
+  - openshift-kube-apiserver-operator
+  - openshift-kube-scheduler
+  - openshift-kube-controller-manager
+  - openshift-kube-controller-manager-operator
+  - openshift-kube-scheduler-operator
+  - openshift-console-operator
+  - openshift-controller-manager
+  - openshift-controller-manager-operator
+  - openshift-cloud-credential-operator
+  - openshift-authentication-operator
+  - openshift-service-ca
+  - openshift-kube-storage-version-migrator-operator
+  - openshift-config-operator
+  - openshift-etcd-operator
+  - openshift-apiserver-operator
+  - openshift-cluster-csi-drivers
+  - openshift-cluster-storage-operator
+  - openshift-cluster-version
+  - openshift-image-registry
+  - openshift-machine-config-operator
+  - openshift-sdn
+  - openshift-service-ca-operator
+
+refreshResources: false
+`
+)
+
+func TurnOffRefreshResources(t *TestArgs) {
+	cmClient := kubeClient.CoreV1().ConfigMaps(client.DefaultNamespace)
+	var cm *corev1.ConfigMap
+	err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (done bool, err error) {
+		cm, err = cmClient.Get(context.TODO(), client.DriverConfigurationConfigMap, metav1.GetOptions{})
+		if err != nil {
+			t.T.Logf("%s: error getting driver config configmap: %v", time.Now().String(), err)
+			return false, nil
+		}
+		t.T.Logf("%s: found driver config configmap", time.Now().String())
+		return true, nil
+	})
+	if err != nil {
+		// try to create
+		//TODO eventually when BUILD-340 is done operator should guarantee this CM exists
+		cm = &corev1.ConfigMap{}
+		cm.Name = client.DriverConfigurationConfigMap
+		cm.Name = client.DefaultNamespace
+		cm.Data = map[string]string{}
+		cm.Data[client.DriverConfigurationDataKey] = noRefreshConfgYaml
+
+		_, err = cmClient.Create(context.TODO(), cm, metav1.CreateOptions{})
+		if err != nil {
+			t.MessageString = "unable to create configuration configmap after not locating it"
+			LogAndDebugTestError(t)
+		}
+		return
+	}
+
+	// update config
+	err = wait.PollImmediate(1*time.Second, 5*time.Second, func() (done bool, err error) {
+		cm, err = cmClient.Get(context.TODO(), client.DriverConfigurationConfigMap, metav1.GetOptions{})
+		if err != nil {
+			t.T.Logf("%s: error getting driver config configmap for update: %v", time.Now().String(), err)
+			return false, nil
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[client.DriverConfigurationDataKey] = noRefreshConfgYaml
+		_, err = cmClient.Update(context.TODO(), cm, metav1.UpdateOptions{})
+		if err != nil {
+			t.T.Logf("%s: error updating driver config configmap: %v", time.Now().String(), err)
+		}
+		t.T.Logf("%s: updated driver config configmap", time.Now().String())
+		return true, nil
+	})
+	if err != nil {
+		t.MessageString = "unable to change config to turn of refresh"
+		LogAndDebugTestError(t)
+	}
+
+}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -12,20 +12,22 @@ var (
 )
 
 type TestArgs struct {
-	T                   *testing.T
-	Name                string
-	SecondName          string
-	SearchString        string
-	MessageString       string
-	ShareToDelete       string
-	ShareToDeleteType   consts.ResourceReferenceType
-	SearchStringMissing bool
-	SecondShare         bool
-	SecondShareSubDir   bool
-	DaemonSetUp         bool
-	TestPodUp           bool
-	ReadOnly            bool
-	TestDuration        time.Duration
+	T                                  *testing.T
+	Name                               string
+	SecondName                         string
+	SearchString                       string
+	MessageString                      string
+	ShareToDelete                      string
+	LogContent                         string
+	CurrentDriverContainerRestartCount map[string]int32
+	ShareToDeleteType                  consts.ResourceReferenceType
+	SearchStringMissing                bool
+	SecondShare                        bool
+	SecondShareSubDir                  bool
+	DaemonSetUp                        bool
+	TestPodUp                          bool
+	ReadOnly                           bool
+	TestDuration                       time.Duration
 }
 
 // LogAndDebugTestError is not intended as a replacement for the use of t.Fatalf through this e2e suite,


### PR DESCRIPTION
It is possible that we need https://github.com/openshift/cluster-storage-operator/pull/231 to merge, so that the initial driver configmap is created

But let's see 

In my local testing, this refactored e2e works when the configmap is present 

@coreydaley @otaviof FYI

I'll officially assign for review once my question ^^ is resolved