### PR TITLE
maintain secret/configmap watches/informers on demand as shares come and go; allow no resource refresh on per volume basis

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,7 +82,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		go runOperator(cfg, driver)
+		go runOperator(cfg)
 		go watchForConfigChanges(cfgManager)
 		driver.Run()
 	},
@@ -127,8 +127,8 @@ func loadSharedresourceClientset() (sharev1clientset.Interface, error) {
 
 // runOperator based on the informed configuration, it will spawn and run the Controller, until
 // trapping OS signals.
-func runOperator(cfg *config.Config, hp hostpath.HostPathDriver) {
-	c, err := controller.NewController(cfg.GetShareRelistInterval(), cfg.RefreshResources, cfg.IgnoredNamespaces, hp)
+func runOperator(cfg *config.Config) {
+	c, err := controller.NewController(cfg.GetShareRelistInterval(), cfg.RefreshResources)
 	if err != nil {
 		fmt.Printf("Failed to set up controller: %s", err.Error())
 		os.Exit(1)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,26 +1,3 @@
 ---
-ignoredNamespaces: 
-  - openshift-machine-api
-  - openshift-kube-apiserver
-  - openshift-kube-apiserver-operator
-  - openshift-kube-scheduler
-  - openshift-kube-controller-manager
-  - openshift-kube-controller-manager-operator
-  - openshift-kube-scheduler-operator
-  - openshift-console-operator
-  - openshift-controller-manager
-  - openshift-controller-manager-operator
-  - openshift-cloud-credential-operator
-  - openshift-authentication-operator
-  - openshift-service-ca
-  - openshift-kube-storage-version-migrator-operator
-  - openshift-config-operator
-  - openshift-etcd-operator
-  - openshift-apiserver-operator
-  - openshift-cluster-csi-drivers
-  - openshift-cluster-storage-operator
-  - openshift-cluster-version
-  - openshift-image-registry
-  - openshift-machine-config-operator
-  - openshift-sdn
-  - openshift-service-ca-operator
+shareRelistInterval: 10m
+refreshResources:  true

--- a/docs/config.md
+++ b/docs/config.md
@@ -26,9 +26,6 @@ shareRelistInterval: 10m
 
 # toggles actively watching for resources, when disabled it will only read objects before mount
 refreshResources: true
-
-# list of namespace names ignored
-ignoredNamespaces: []
 ```
 
 When the file is not present, the driver assumes default values instead. And, when the configuration

--- a/pkg/cache/shares.go
+++ b/pkg/cache/shares.go
@@ -1,12 +1,13 @@
 package cache
 
 import (
-	"github.com/openshift/csi-driver-shared-resource/pkg/client"
 	"sync"
 
-	"k8s.io/klog/v2"
-
 	sharev1alpha1 "github.com/openshift/api/sharedresource/v1alpha1"
+	"github.com/openshift/csi-driver-shared-resource/pkg/client"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 )
 
 /*
@@ -94,6 +95,28 @@ func UpdateSharedConfigMap(share *sharev1alpha1.SharedConfigMap) {
 func UpdateSharedSecret(share *sharev1alpha1.SharedSecret) {
 	klog.V(4).Infof("UpdateSharedSecret key %s", share.Name)
 	AddSharedSecret(share)
+}
+
+func NamespacesWithSharedConfigMaps() map[string]struct{} {
+	namespacesMap := map[string]struct{}{}
+	list, err := client.GetListers().SharedConfigMaps.List(labels.Everything())
+	if err == nil {
+		for _, scm := range list {
+			namespacesMap[scm.Spec.ConfigMapRef.Namespace] = struct{}{}
+		}
+	}
+	return namespacesMap
+}
+
+func NamespacesWithSharedSecrets() map[string]struct{} {
+	namespacesMap := map[string]struct{}{}
+	list, err := client.GetListers().SharedSecrets.List(labels.Everything())
+	if err == nil {
+		for _, ss := range list {
+			namespacesMap[ss.Spec.SecretRef.Namespace] = struct{}{}
+		}
+	}
+	return namespacesMap
 }
 
 // DelSharedConfigMap removes the SharedConfigMap from our various tracking maps and calls the registered callbacks

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,8 +12,6 @@ const DefaultResyncDuration = 10 * time.Minute
 type Config struct {
 	// ShareRelistInterval interval to relist all "Share" object instances.
 	ShareRelistInterval string `yaml:"shareRelistInterval,omitempty"`
-	// IgnoredNamespaces namespace names ignored by this controller.
-	IgnoredNamespaces []string `yaml:"ignoredNamespaces,omitempty"`
 	// RefreshResources toggles actively watching for resources, when disabled it will only read
 	// resources before mount.
 	RefreshResources bool `yaml:"refreshResources,omitempty"`
@@ -36,7 +34,6 @@ func (c *Config) GetShareRelistInterval() time.Duration {
 func NewConfig() Config {
 	return Config{
 		ShareRelistInterval: DefaultResyncDuration.String(),
-		IgnoredNamespaces:   []string{},
 		RefreshResources:    true,
 	}
 }

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -38,7 +38,6 @@ func TestConfig_LocalConfigFile(t *testing.T) {
 	expectedCfg := NewConfig()
 	expectedCfg.RefreshResources = false
 	expectedCfg.ShareRelistInterval = "20m"
-	expectedCfg.IgnoredNamespaces = []string{"namespace-a", "namespace-b", "namespace-c"}
 	if !reflect.DeepEqual(&expectedCfg, cfg) {
 		t.Fatalf("configuration instance '%#v', is not equal to excepted", cfg)
 	}

--- a/pkg/hostpath/constants.go
+++ b/pkg/hostpath/constants.go
@@ -17,6 +17,7 @@ const (
 	CSIEphemeral                       = "csi.storage.k8s.io/ephemeral"
 	SharedConfigMapShareKey            = "sharedConfigMap"
 	SharedSecretShareKey               = "sharedSecret"
+	RefreshResource                    = "refreshResource"
 	bindDir                            = "bind-dir"
 	mountAccess             accessType = iota
 )

--- a/pkg/hostpath/hpv.go
+++ b/pkg/hostpath/hpv.go
@@ -29,6 +29,7 @@ type hostPathVolume struct {
 	PodUID              string     `json:"podUID"`
 	PodSA               string     `json:"podSA"`
 	ReadOnly            bool       `json:"readOnly"`
+	Refresh             bool       `json:"refresh"`
 	// hpv's can be accessed/modified by both the sharedSecret/SharedConfigMap events and the configmap/secret events; to prevent data races
 	// we serialize access to a given hpv with a per hpv mutex stored in this map; access to hpv fields should not
 	// be done directly, but only by each field's getter and setter.  Getters and setters then leverage the per hpv
@@ -115,6 +116,12 @@ func (hpv *hostPathVolume) IsReadOnly() bool {
 	return hpv.ReadOnly
 }
 
+func (hpv *hostPathVolume) IsRefresh() bool {
+	hpv.Lock.Lock()
+	defer hpv.Lock.Unlock()
+	return hpv.Refresh
+}
+
 func (hpv *hostPathVolume) SetVolName(volName string) {
 	hpv.Lock.Lock()
 	defer hpv.Lock.Unlock()
@@ -180,6 +187,12 @@ func (hpv *hostPathVolume) SetReadOnly(readOnly bool) {
 	hpv.Lock.Lock()
 	defer hpv.Lock.Unlock()
 	hpv.ReadOnly = readOnly
+}
+
+func (hpv *hostPathVolume) SetRefresh(refresh bool) {
+	hpv.Lock.Lock()
+	defer hpv.Lock.Unlock()
+	hpv.Refresh = refresh
 }
 
 func (hpv *hostPathVolume) StoreToDisk() error {

--- a/pkg/hostpath/nodeserver_test.go
+++ b/pkg/hostpath/nodeserver_test.go
@@ -474,7 +474,31 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
-			name:    "inputs are OK for configmap",
+			name:        "inputs are OK for secret, no refresh",
+			secretShare: validSharedSecret,
+			reactor:     acceptReactorFunc,
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeId:   "testvolid1",
+				Readonly:   true,
+				TargetPath: getTestTargetPath(t),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+				VolumeContext: map[string]string{
+					CSIEphemeral:         "true",
+					CSIPodName:           "name1",
+					CSIPodNamespace:      "namespace1",
+					CSIPodUID:            "uid1",
+					CSIPodSA:             "sa1",
+					SharedSecretShareKey: "share1",
+					RefreshResource:      "false",
+				},
+			},
+		},
+		{
+			name:    "inputs are OK for configmap, no refresh",
 			cmShare: validSharedConfigMap,
 			reactor: acceptReactorFunc,
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
@@ -493,6 +517,55 @@ func TestNodePublishVolume(t *testing.T) {
 					CSIPodUID:               "uid1",
 					CSIPodSA:                "sa1",
 					SharedConfigMapShareKey: "share1",
+					RefreshResource:         "false",
+				},
+			},
+		},
+		{
+			name:        "inputs are OK for secret, no refresh",
+			secretShare: validSharedSecret,
+			reactor:     acceptReactorFunc,
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeId:   "testvolid1",
+				Readonly:   true,
+				TargetPath: getTestTargetPath(t),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+				VolumeContext: map[string]string{
+					CSIEphemeral:         "true",
+					CSIPodName:           "name1",
+					CSIPodNamespace:      "namespace1",
+					CSIPodUID:            "uid1",
+					CSIPodSA:             "sa1",
+					SharedSecretShareKey: "share1",
+					RefreshResource:      "false",
+				},
+			},
+		},
+		{
+			name:    "inputs are OK for configmap, no refresh",
+			cmShare: validSharedConfigMap,
+			reactor: acceptReactorFunc,
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeId:   "testvolid1",
+				Readonly:   true,
+				TargetPath: getTestTargetPath(t),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+				VolumeContext: map[string]string{
+					CSIEphemeral:            "true",
+					CSIPodName:              "name1",
+					CSIPodNamespace:         "namespace1",
+					CSIPodUID:               "uid1",
+					CSIPodSA:                "sa1",
+					SharedConfigMapShareKey: "share1",
+					RefreshResource:         "false",
 				},
 			},
 		},

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -1,7 +1,3 @@
 ---
 refreshResources: false
 shareRelistInterval: 20m
-ignoredNamespaces: 
-  - namespace-a
-  - namespace-b
-  - namespace-c

--- a/test/e2e/normal_test.go
+++ b/test/e2e/normal_test.go
@@ -55,6 +55,17 @@ func coreTestBasicThenNoShareThenShare(testArgs *framework.TestArgs) {
 	framework.ExecPod(testArgs)
 }
 
+func TestBasicNoRefresh(t *testing.T) {
+	testArgs := &framework.TestArgs{
+		T:         t,
+		NoRefresh: false,
+	}
+	prep(testArgs)
+	framework.CreateTestNamespace(testArgs)
+	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
+	basicShareSetupAndVerification(testArgs)
+}
+
 func TestBasicThenNoShareThenShareReadWrite(t *testing.T) {
 	testArgs := &framework.TestArgs{
 		T: t,

--- a/test/framework/configmap.go
+++ b/test/framework/configmap.go
@@ -14,32 +14,6 @@ import (
 const (
 	noRefreshConfgYaml = `
 ---
-ignoredNamespaces: 
-  - openshift-machine-api
-  - openshift-kube-apiserver
-  - openshift-kube-apiserver-operator
-  - openshift-kube-scheduler
-  - openshift-kube-controller-manager
-  - openshift-kube-controller-manager-operator
-  - openshift-kube-scheduler-operator
-  - openshift-console-operator
-  - openshift-controller-manager
-  - openshift-controller-manager-operator
-  - openshift-cloud-credential-operator
-  - openshift-authentication-operator
-  - openshift-service-ca
-  - openshift-kube-storage-version-migrator-operator
-  - openshift-config-operator
-  - openshift-etcd-operator
-  - openshift-apiserver-operator
-  - openshift-cluster-csi-drivers
-  - openshift-cluster-storage-operator
-  - openshift-cluster-version
-  - openshift-image-registry
-  - openshift-machine-config-operator
-  - openshift-sdn
-  - openshift-service-ca-operator
-
 refreshResources: false
 `
 )

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -17,6 +17,7 @@ import (
 	kubexec "k8s.io/kubectl/pkg/cmd/exec"
 
 	"github.com/openshift/csi-driver-shared-resource/pkg/client"
+	"github.com/openshift/csi-driver-shared-resource/pkg/hostpath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 )
@@ -60,6 +61,9 @@ func CreateTestPod(t *TestArgs) {
 			},
 			ServiceAccountName: "default",
 		},
+	}
+	if t.NoRefresh {
+		pod.Spec.Volumes[0].VolumeSource.CSI.VolumeAttributes[hostpath.RefreshResource] = "false"
 	}
 	if t.SecondShare {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -28,6 +28,7 @@ type TestArgs struct {
 	DaemonSetUp                        bool
 	TestPodUp                          bool
 	ReadOnly                           bool
+	NoRefresh                          bool
 	TestDuration                       time.Duration
 }
 


### PR DESCRIPTION
@openshift/openshift-team-build-api - this PR changes how we watch configmaps/secrets across namespaaces.  Where rather than watch all namespaces, but excluded some system namespaces (where that list is configurable with a series of stories from @otaviof), I create the secret/configmap shared informer related artifacts as shares are defined and recognized by this controller/driver, where we inspect the share to see what the specific namespace of the shared item is.

On share delete, we stop / prune a given namespace's shared informers if no more shares exist that point to that namespace; at the moment if is totally watch/relist event driven ... a later iteration may add an addition background monitoring loop (curious what folks think here)

but with a change like this, our scaling footprint/concerns out of the box are in many ways mitigated if this approach holds up, as we are only watching namespaces for whatever shares are created (if a user creates 1000s of shares across 1000s of namespaces, we can then tell them "don't do that" or "give our driver a bunch of extra memory" or some such)

and the reality is we do not envision such numbers at this time

additionally, if we move forward with this, tweaking the existing config probably makes sense
- don't need a  list of "ignored" namespaces
