### PR TITLE
metrics: split openshift_csi_share_mount_total into total and failures

### DIFF
--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -254,7 +254,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// here is what initiates that necessary copy now with *NOT* using bind on the mount so each pod gets its own tmpfs
 	if err := ns.hp.mapVolumeToPod(vol); err != nil {
-		metrics.IncMountCounter(false)
+		metrics.IncMountCounters(false)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to populate mount device: %s at %s: %s",
 			bindDir,
 			kubeletTargetPath,
@@ -262,12 +262,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	if err := vol.StoreToDisk(); err != nil {
-		metrics.IncMountCounter(false)
+		metrics.IncMountCounters(false)
 		klog.Errorf("failed to persist driver volume metadata to disk: %s", err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	metrics.IncMountCounter(true)
+	metrics.IncMountCounters(true)
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -34,9 +34,10 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "One true, two false",
 			expected: []string{
-				`# TYPE openshift_csi_share_mount_total counter`,
-				`openshift_csi_share_mount_total{succeeded="false"} 2`,
-				`openshift_csi_share_mount_total{succeeded="true"} 1`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`openshift_csi_share_mount_requests_total 3`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`openshift_csi_share_mount_failures_total 2`,
 			},
 			mounts:      map[bool]int{true: 1, false: 2},
 			notExpected: []string{},
@@ -44,33 +45,40 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "Two true, no false",
 			expected: []string{
-				`# TYPE openshift_csi_share_mount_total counter`,
-				`openshift_csi_share_mount_total{succeeded="true"} 2`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`openshift_csi_share_mount_requests_total 2`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`openshift_csi_share_mount_failures_total 0`,
 			},
 			notExpected: []string{
-				`openshift_csi_share_mount_total{succeeded="false"}`,
+				`openshift_csi_share_mount_failures_total 1`,
 			},
 			mounts: map[bool]int{true: 2},
 		},
 		{
 			name: "No true, three false",
 			expected: []string{
-				`# TYPE openshift_csi_share_mount_total counter`,
-				`openshift_csi_share_mount_total{succeeded="false"} 3`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`openshift_csi_share_mount_requests_total 3`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`openshift_csi_share_mount_failures_total 3`,
 			},
 			notExpected: []string{
-				`openshift_csi_share_mount_total{succeeded="true"}`,
+				`openshift_csi_share_mount_failures_total 0`,
+				`openshift_csi_share_mount_failures_total 1`,
+				`openshift_csi_share_mount_failures_total 2`,
 			},
 			mounts: map[bool]int{false: 3},
 		},
 	} {
 		registry := prometheus.NewRegistry()
-		mountCounter = createMountCounter()
+		mountCounter, failedMountCounter = createMountCounters()
 		registry.MustRegister(mountCounter)
+		registry.MustRegister(failedMountCounter)
 
 		for k, v := range test.mounts {
 			for i := 0; i < v; i += 1 {
-				IncMountCounter(k)
+				IncMountCounters(k)
 			}
 		}
 


### PR DESCRIPTION
As proposed in https://github.com/openshift/cluster-monitoring-operator/pull/1477 this spits the metric `openshift_csi_share_mount_total` into `openshift_csi_share_mount_requests_total` and `openshift_csi_share_mount_failures_total`.

Feel free to stick with what is in the code now. I wanted to propose this as I approved the current state in #54.