### PR TITLE
Split and rename sci share mount total metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"strconv"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -11,28 +9,44 @@ const (
 
 	sharesSubsystem = "openshift_csi_share"
 
-	mount          = "mount"
-	mountCountName = sharesSubsystem + separator + mount + separator + "total"
+	mount    = "mount"
+	requests = "requests"
+	failed   = "failures"
+
+	mountCountName  = sharesSubsystem + separator + mount + separator + requests + separator + "total"
+	mountFailedName = sharesSubsystem + separator + mount + separator + failed + separator + "total"
 
 	MetricsPort = 6000
 )
 
 var (
-	mountCounter = createMountCounter()
+	mountCounter       = createMountCounter()
+	mountFailedCounter = createMountFailedCounter()
 )
 
-func createMountCounter() *prometheus.CounterVec {
-	return prometheus.NewCounterVec(prometheus.CounterOpts{
+func createMountCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
 		Name: mountCountName,
-		Help: "Counts share volume mount attempts by success. " +
-			"'succeeded' label will hold 'true' in case of succeeded mount, and 'false' otherwise.",
-	}, []string{"succeeded"})
+		Help: "Counts all attempts for csi driver volume mounts.",
+	})
+}
+
+func createMountFailedCounter() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Name: mountFailedName,
+		Help: "Counts failed mount attempts for csi driver volume mounts.",
+	})
 }
 
 func init() {
 	prometheus.MustRegister(mountCounter)
+	prometheus.MustRegister(mountFailedCounter)
 }
 
-func IncMountCounter(succeeded bool) {
-	mountCounter.With(prometheus.Labels{"succeeded": strconv.FormatBool(succeeded)}).Inc()
+func IncMountCounter() {
+	mountCounter.Inc()
+}
+
+func IncMountFailedCounter() {
+	mountFailedCounter.Inc()
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -34,9 +34,10 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "One true, two false",
 			expected: []string{
-				`# TYPE openshift_csi_share_mount_total counter`,
-				`openshift_csi_share_mount_total{succeeded="false"} 2`,
-				`openshift_csi_share_mount_total{succeeded="true"} 1`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`# TYPE openshift_csi_share_mount_failures_total counter`,
+				`openshift_csi_share_mount_requests_total 3`,
+				`openshift_csi_share_mount_failures_total 2`,
 			},
 			mounts:      map[bool]int{true: 1, false: 2},
 			notExpected: []string{},
@@ -44,8 +45,10 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "Two true, no false",
 			expected: []string{
-				`# TYPE openshift_csi_share_mount_total counter`,
-				`openshift_csi_share_mount_total{succeeded="true"} 2`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`# TYPE openshift_csi_share_mount_failures_total counter`,
+				`openshift_csi_share_mount_requests_total 2`,
+				`openshift_csi_share_mount_failures_total 0`,
 			},
 			notExpected: []string{
 				`openshift_csi_share_mount_total{succeeded="false"}`,
@@ -55,8 +58,10 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "No true, three false",
 			expected: []string{
-				`# TYPE openshift_csi_share_mount_total counter`,
-				`openshift_csi_share_mount_total{succeeded="false"} 3`,
+				`# TYPE openshift_csi_share_mount_requests_total counter`,
+				`# TYPE openshift_csi_share_mount_failures_total counter`,
+				`openshift_csi_share_mount_requests_total 3`,
+				`openshift_csi_share_mount_failures_total 3`,
 			},
 			notExpected: []string{
 				`openshift_csi_share_mount_total{succeeded="true"}`,
@@ -66,11 +71,16 @@ func TestMetrics(t *testing.T) {
 	} {
 		registry := prometheus.NewRegistry()
 		mountCounter = createMountCounter()
+		mountFailedCounter = createMountFailedCounter()
 		registry.MustRegister(mountCounter)
+		registry.MustRegister(mountFailedCounter)
 
 		for k, v := range test.mounts {
 			for i := 0; i < v; i += 1 {
-				IncMountCounter(k)
+				IncMountCounter()
+				if !k {
+					IncMountFailedCounter()
+				}
 			}
 		}
 


### PR DESCRIPTION
Monitoring team recommends to split `success`/`fail` labels into different metrics and call them `fail_total` and `requests_total` in order to be able to access failed percentage easily.