### PR TITLE
Support TLS in the metrics endpoint

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -11,6 +11,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	// these files are mounted from the openshift secret
+	// shared-resource-csi-driver-node-metrics-serving-cert
+	// by the csi-driver-shared-resource-operator
+	tlsCRT = "/etc/secrets/tls.crt"
+	tlsKey = "/etc/secrets/tls.key"
+)
+
 // BuildServer creates the http.Server struct
 func BuildServer(port int) (*http.Server, error) {
 	if port <= 0 {
@@ -41,7 +49,7 @@ func StopServer(srv *http.Server) {
 // RunServer starts the metrics server.
 func RunServer(srv *http.Server, stopCh <-chan struct{}) {
 	go func() {
-		err := srv.ListenAndServe()
+		err := srv.ListenAndServeTLS(tlsCRT, tlsKey)
 		if err != nil && err != http.ErrServerClosed {
 			klog.Errorf("error starting metrics server: %v", err)
 		}


### PR DESCRIPTION
Metrics endpoint must now support TLS provided in the secret mounted by the CSI SR operator.