### PR TITLE
BUILD-381: require CSI Volumes using the Shared Resources driver to be specified as readOnly == true

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/mount"
 
 	sharev1clientset "github.com/openshift/client-go/sharedresource/clientset/versioned"
 	"github.com/openshift/csi-driver-shared-resource/pkg/cache"
@@ -77,6 +78,7 @@ var rootCmd = &cobra.Command{
 			endPoint,
 			maxVolumesPerNode,
 			version,
+			mount.New(""),
 		)
 		if err != nil {
 			fmt.Printf("Failed to initialize driver: %s", err.Error())

--- a/docs/csi.md
+++ b/docs/csi.md
@@ -6,11 +6,11 @@ So let's take each part of the [CSIVolumeSource](https://github.com/kubernetes/a
 - for the `VolumeAttributes` map, this driver currently inspects the "sharedConfigMap" key or "sharedSecret" key (which map the `SharedConfigMap` OR `SharedSecret` instance your `Pod` wants to use) in addition to the
   elements of the `Pod` the kubelet stores when contacting the driver to provision the `Volume`.  See [this list](https://github.com/openshift/csi-driver-shared-resource/blob/c3f1c454f92203f4b406dabe8dd460782cac1d03/pkg/hostpath/nodeserver.go#L37-L42).
 - NOTE: you cannot specify both a "sharedConfigMap" and "sharedSecret" key.  An error will be flagged.  An error will also be flagged if neither is present, or if the value for one or the other does not equal the name of a `SharedConfigMap` or `SharedSecret`
-- the `ReadOnly` field is honored.  The driver can even update the content for a read-only `Volume`, even as the `Pod` consuming the `Volume` cannot write to the `Volume`.  However,
-  a limitation exists which makes any updates of content for read-only `Volumes` *OFFICIALLY* unsupported.  Namely, the function will not work across driver restarts.  The driver
-  loses access to the kubelet's mount for the `Volume`.  This is not the case for read-write `Volumes`.  The driver is able to update the content of read-write `Volumes` provisioned before the 
-  latest restart of the driver.
-- Also, mounting of one `SharedConfigMap` OR `SharedSecret` off of a subdirectory of another `SharedConfigMap` OR `SharedSecret` is only supported with read-write `Volumes`.  
+- the `ReadOnly` field is required to be set to 'true'.  This follows conventions introduced in upstream Kubernetes CSI Drivers to facilitate proper SELinux labelling.  What occurs is that
+this driver will return a read-write linux file system to the kubelet, so that CRI-O can apply the correct SELinux labels on the file system (CRI-O would not be able to update the SELinux labels on a read only file system
+after it is created), but the kubelet still makes sure that the file system later exposed to the consuming pod (which sits on top of the file system returned by this repository's driver) is read only.
+If this driver allowed both read-only and read-write, there is in fact no way to provide differing support that still allows for correct SELinux labelling for each).
+- Also, mounting of one `SharedConfigMap` OR `SharedSecret` off of a subdirectory of another `SharedConfigMap` OR `SharedSecret` is *NOT* supported. The driver only supports read-only `Volumes`.  
 - the `FSType` field is ignored.  This driver by design only supports `tmpfs`, with a different mount performed for each `Volume`, in order to defer all SELinux concerns to the kubelet.
 - the `NodePublishSecretRef` field is ignored.  The CSI `NodePublishVolume` and `NodeUnpublishVolume` flows gate the permission evaluation required for the `Volume`
   by performing `SubjectAccessReviews` against the reference `SharedConfigMap` OR `SharedSecret` instance, using the `serviceAccount` of the `Pod` as the subject.

--- a/examples/csi-app.yaml
+++ b/examples/csi-app.yaml
@@ -26,7 +26,7 @@ spec:
   volumes:
     - name: my-csi-volume
       csi:
-        #readOnly: true
+        readOnly: true
         driver: csi.sharedresource.openshift.io
         volumeAttributes:
           sharedConfigMap: my-share

--- a/pkg/hostpath/hpv.go
+++ b/pkg/hostpath/hpv.go
@@ -28,7 +28,6 @@ type hostPathVolume struct {
 	PodName             string     `json:"podName"`
 	PodUID              string     `json:"podUID"`
 	PodSA               string     `json:"podSA"`
-	ReadOnly            bool       `json:"readOnly"`
 	Refresh             bool       `json:"refresh"`
 	// hpv's can be accessed/modified by both the sharedSecret/SharedConfigMap events and the configmap/secret events; to prevent data races
 	// we serialize access to a given hpv with a per hpv mutex stored in this map; access to hpv fields should not
@@ -110,12 +109,6 @@ func (hpv *hostPathVolume) GetPodSA() string {
 	defer hpv.Lock.Unlock()
 	return hpv.PodSA
 }
-func (hpv *hostPathVolume) IsReadOnly() bool {
-	hpv.Lock.Lock()
-	defer hpv.Lock.Unlock()
-	return hpv.ReadOnly
-}
-
 func (hpv *hostPathVolume) IsRefresh() bool {
 	hpv.Lock.Lock()
 	defer hpv.Lock.Unlock()
@@ -183,12 +176,6 @@ func (hpv *hostPathVolume) SetPodSA(sa string) {
 	defer hpv.Lock.Unlock()
 	hpv.PodSA = sa
 }
-func (hpv *hostPathVolume) SetReadOnly(readOnly bool) {
-	hpv.Lock.Lock()
-	defer hpv.Lock.Unlock()
-	hpv.ReadOnly = readOnly
-}
-
 func (hpv *hostPathVolume) SetRefresh(refresh bool) {
 	hpv.Lock.Lock()
 	defer hpv.Lock.Unlock()

--- a/pkg/hostpath/nodeserver_test.go
+++ b/pkg/hostpath/nodeserver_test.go
@@ -70,7 +70,6 @@ func testNodeServer(testName string) (*nodeServer, string, string, error) {
 		nodeID:            "node1",
 		maxVolumesPerNode: 0,
 		mounter:           mount.NewFakeMounter([]mount.MountPoint{}),
-		readOnlyMounter:   &WriteOnceReadMany{},
 		readWriteMounter:  &ReadWriteMany{},
 		hp:                hp,
 	}
@@ -426,6 +425,29 @@ func TestNodePublishVolume(t *testing.T) {
 				},
 			},
 			expectedMsg: "PermissionDenied",
+		},
+		{
+			name:    "read only flag not set to true",
+			cmShare: validSharedConfigMap,
+			reactor: acceptReactorFunc,
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeId:   "testvolid1",
+				TargetPath: getTestTargetPath(t),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+				VolumeContext: map[string]string{
+					CSIEphemeral:            "true",
+					CSIPodName:              "name1",
+					CSIPodNamespace:         "namespace1",
+					CSIPodUID:               "uid1",
+					CSIPodSA:                "sa1",
+					SharedConfigMapShareKey: "share1",
+				},
+			},
+			expectedMsg: "The Shared Resource CSI driver requires all volume requests to set read-only to",
 		},
 		{
 			name:    "inputs are OK for configmap",

--- a/test/e2e/disruptive_test.go
+++ b/test/e2e/disruptive_test.go
@@ -37,12 +37,3 @@ func TestBasicThenDriverRestartThenChangeShare(t *testing.T) {
 		inner(testArgs, t)
 	}
 }
-
-func TestBasicThenDriverRestartThenChangeShareWithReadOnlyMount(t *testing.T) {
-	testArgs := &framework.TestArgs{
-		T: t,
-	}
-	testArgs.ReadOnly = true
-	prep(testArgs)
-	inner(testArgs, t)
-}

--- a/test/e2e/normal_test.go
+++ b/test/e2e/normal_test.go
@@ -73,14 +73,6 @@ func TestBasicThenNoShareThenShareReadWrite(t *testing.T) {
 	coreTestBasicThenNoShareThenShare(testArgs)
 }
 
-func TestBasicThenNoShareThenShareReadOnly(t *testing.T) {
-	testArgs := &framework.TestArgs{
-		T:        t,
-		ReadOnly: true,
-	}
-	coreTestBasicThenNoShareThenShare(testArgs)
-}
-
 func coreTestTwoSharesSeparateMountPaths(testArgs *framework.TestArgs) {
 	prep(testArgs)
 	framework.CreateTestNamespace(testArgs)
@@ -88,17 +80,9 @@ func coreTestTwoSharesSeparateMountPaths(testArgs *framework.TestArgs) {
 	doubleShareSetupAndVerification(testArgs)
 }
 
-func TestTwoSharesSeparateMountPathsReadWrite(t *testing.T) {
+func TestTwoSharesSeparateMountPaths(t *testing.T) {
 	testArgs := &framework.TestArgs{
 		T: t,
-	}
-	coreTestTwoSharesSeparateMountPaths(testArgs)
-}
-
-func TestTwoSharesSeparateMountPathsReadOnly(t *testing.T) {
-	testArgs := &framework.TestArgs{
-		T:        t,
-		ReadOnly: true,
 	}
 	coreTestTwoSharesSeparateMountPaths(testArgs)
 }
@@ -115,57 +99,3 @@ to rootfs at \\\"/var/lib/containers/storage/overlay/9a2c6dad956e911bd02c369d0cb
 caused: mkdir /var/lib/containers/storage/overlay/9a2c6dad956e911bd02c369d0cbd013312b514dee81993913769ac81d248b565/merged/data/data-second-share: read-only file system\"\n"
 
 */
-
-func TestTwoSharesSeparateButInheritedMountPaths(t *testing.T) {
-	testArgs := &framework.TestArgs{
-		T: t,
-	}
-	prep(testArgs)
-	framework.CreateTestNamespace(testArgs)
-	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
-	testArgs.SecondShareSubDir = true
-	doubleShareSetupAndVerification(testArgs)
-}
-
-func TestTwoSharesSeparateButInheritedMountPathsRemoveSubPath(t *testing.T) {
-	testArgs := &framework.TestArgs{
-		T: t,
-	}
-	prep(testArgs)
-	framework.CreateTestNamespace(testArgs)
-	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
-	testArgs.SecondShareSubDir = true
-	doubleShareSetupAndVerification(testArgs)
-
-	testArgs.ShareToDelete = testArgs.SecondName
-	testArgs.ShareToDeleteType = consts.ResourceReferenceTypeSecret
-	framework.DeleteShare(testArgs)
-	testArgs.TestDuration = 30 * time.Second
-	testArgs.SearchString = "invoker"
-	framework.ExecPod(testArgs)
-
-	testArgs.SearchStringMissing = true
-	testArgs.SearchString = ".dockerconfigjson"
-	framework.ExecPod(testArgs)
-}
-
-func TestTwoSharesSeparateButInheritedMountPathsRemoveTopPath(t *testing.T) {
-	testArgs := &framework.TestArgs{
-		T: t,
-	}
-	prep(testArgs)
-	framework.CreateTestNamespace(testArgs)
-	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
-	testArgs.SecondShareSubDir = true
-	doubleShareSetupAndVerification(testArgs)
-
-	testArgs.ShareToDeleteType = consts.ResourceReferenceTypeConfigMap
-	framework.DeleteShare(testArgs)
-	testArgs.TestDuration = 30 * time.Second
-	testArgs.SearchString = ".dockerconfigjson"
-	framework.ExecPod(testArgs)
-
-	testArgs.SearchStringMissing = true
-	testArgs.SearchString = "invoker"
-	framework.ExecPod(testArgs)
-}

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -28,6 +28,7 @@ const (
 
 func CreateTestPod(t *TestArgs) {
 	t.T.Logf("%s: start create test pod %s", time.Now().String(), t.Name)
+	truVal := true
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.Name,
@@ -39,7 +40,7 @@ func CreateTestPod(t *TestArgs) {
 					Name: "my-csi-volume",
 					VolumeSource: corev1.VolumeSource{
 						CSI: &corev1.CSIVolumeSource{
-							ReadOnly:         &t.ReadOnly,
+							ReadOnly:         &truVal,
 							Driver:           string(operatorv1.SharedResourcesCSIDriver),
 							VolumeAttributes: map[string]string{"sharedConfigMap": t.Name},
 						},
@@ -70,7 +71,7 @@ func CreateTestPod(t *TestArgs) {
 			Name: "my-csi-volume" + secondShareSuffix,
 			VolumeSource: corev1.VolumeSource{
 				CSI: &corev1.CSIVolumeSource{
-					ReadOnly:         &t.ReadOnly,
+					ReadOnly:         &truVal,
 					Driver:           string(operatorv1.SharedResourcesCSIDriver),
 					VolumeAttributes: map[string]string{"sharedSecret": t.SecondName},
 				},

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -27,7 +27,6 @@ type TestArgs struct {
 	SecondShareSubDir                  bool
 	DaemonSetUp                        bool
 	TestPodUp                          bool
-	ReadOnly                           bool
 	NoRefresh                          bool
 	TestDuration                       time.Duration
 }


### PR DESCRIPTION
Also fixed a doc update that was missed when I changed the controller watch to listen to the namespaces that are referenced by shares instead of listening to all namespaces but filter out some openshift system namespaces.

/assign @coreydaley 
a lot of deleted code 
I would also use `?w=1` at the end of the git URL used during code review in your browser to filter down white space differences 

for PR review

@akram FYI - yeah a fair amount of e2e reduction was needed since we can no longer support shares mounted off other shares since we require read only to be true