### PR TITLE
add custom must-gather image for 'oc adm must-gather'

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,0 +1,9 @@
+FROM registry.ci.openshift.org/ocp/4.10:must-gather AS builder
+WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
+COPY . .
+
+FROM registry.ci.openshift.org/ocp/4.10:cli
+COPY --from=builder /go/src/github.com/openshift/csi-driver-shared-resource/must-gather/* /usr/bin/
+RUN chmod +x /usr/bin/gather
+
+ENTRYPOINT /usr/bin/gather

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,12 @@ build-image: ## Build the images and push them to the remote registry. Example: 
 	$(CONTAINER_RUNTIME) push $(REGISTRY)/$(REPOSITORY)/origin-csi-driver-shared-resource:$(TAG)
 .PHONY: build-image
 
+build-mustgather-image: ## Build the customer must gather images and push them to the remote registry. Example: make build-mustgather-image
+	rm -rf _output
+	$(CONTAINER_RUNTIME) build -f Dockerfile.mustgather -t $(REGISTRY)/$(REPOSITORY)/origin-csi-driver-shared-resource-mustgather:$(TAG) .
+	$(CONTAINER_RUNTIME) push $(REGISTRY)/$(REPOSITORY)/origin-csi-driver-shared-resource-mustgather:$(TAG)
+.PHONY: build-mustgather-image
+
 clean: ## Clean up the workspace. Example: make clean
 	rm -rf _output
 .PHONY: clean

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+pods=()
+
+cdsrNamespace="openshift-cluster-csi-drivers"
+for I in $(oc get pod -n ${cdsrNamespace} -o custom-columns=NAME:.metadata.name --no-headers); do
+  pods+=("$I")
+done
+
+object_collection_path=must-gather/cluster-scoped-resources/sharedresource.openshift.io
+mkdir -p ${object_collection_path}
+
+for pod in "${pods[@]}"; do
+  if [[ $pod != shared-resource-csi-driver-node* ]] ;
+  then
+    continue
+  fi
+  mkdir -p ${object_collection_path}/"$pod"
+  oc rsync -c hostpath -n ${cdsrNamespace} "$pod":/csi-volumes-map ${object_collection_path}/"$pod"
+done
+
+exit 0


### PR DESCRIPTION
See https://docs.openshift.com/container-platform/4.9/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data for how some other "features" provide additional must-gather semantics.

I patterned this after what was done in the local-storage-operator.  That feature seemed the closest / most similar to what shared resources is.

So in theory we would ultimately have an image like `registry.redhat.io/openshift4/ocp-shared-resource-mustgather-rhel8` image available.

Based on the pattern demonstrated there, it does not look like we want to pursue getting this in the payload.  However perhaps a question to ask (during the 4.11 cycle)

Next question, does that mean we still pursue things through ART, since shared resources is part of the payload, regardless of where our must-gather image lands, or is this a CPaaS item.  Based on the recent 4.11 kick off, that has me leaning toward guessing CPaaS.

That said, after this PR merges, I think we can still pursue openshift/release work for the new image, even before any payload/ART/CPaas decisions, like what occurred with shared resources.  IIRC, that at least gets us a quay.io/openshift/origin-... image that we could direct customers too in a pinch.

Given that, perhaps we pursue merging this and an openshift/release PR before 4.10 code freeze.

But let's discuss.

Finally, FYI, `shellcheck` reports no items to correct with the new bash file `gather`.  I did not add the `.sh` suffix because that is what local-storage-operator did.

@openshift/openshift-team-build-api FYI / ptal

Testing locally, running `oc adm must-gather --image=docker.io/gmontero/origin-csi-driver-shared-resource-mustgather:latest` adds the provisioned volume metadata the driver stores in its `/csi-volumes-map` hostpath volume in a subfolder under the cluster scoped resources -> shared resources folder.  That lines up with what https://github.com/openshift/cluster-storage-operator/pull/257 will create when gathering shared resources instances when base OCP must gather is run.