### PR TITLE
add Tekton example, update/correction to README and existing example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ NOTE: see [CSI Volume Specifics](docs/csi.md) for restrictions around these feat
 ## Getting Started
 
 The maintenance of the related API objects and the deployment of this CSI driver are handled via the [Openshift CSI Driver for Shared Resources Operator](https://github.com/openshift/csi-driver-shared-resource-operator)
-when you are using a Tech Preview OpenShift Cluster in 4.10.  The 4.10 release docs are not out yet with 4.10 still under development,
-but these [4.9 docs](https://docs.openshift.com/container-platform/4.9/post_installation_configuration/cluster-tasks.html#post-install-tp-tasks) are 
+when you are using a Tech Preview OpenShift Cluster in 4.10.  The 4.10 release docs are [here](https://docs.openshift.com/container-platform/4.10/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.html),
+and these [4.10 docs](https://docs.openshift.com/container-platform/4.10/post_installation_configuration/cluster-tasks.html#post-install-tp-tasks) are 
 sufficient for explaining how to turn on Tech Preview features after install.
 
 For running on a 4.10 cluster which is *NOT* a Tech Preview cluster, you must employ the methodology described in the [Local Devlopment](#local-development)

--- a/docs/build-with-rhel-entitlements.md
+++ b/docs/build-with-rhel-entitlements.md
@@ -1,6 +1,14 @@
 # BuildConfig example
 
-From the root directory, create/apply the various API objects defined in the YAML files in the `./examples` directory.
+As noted in this repositories [main README](../README.md#getting-started), Shared Resources are currently only available
+on 'TechPreviewNoUpgrade' clusters.  So, unless you are employing [local development](../README.md#local-development)
+you can convert your cluster to Tech Preview via:
+
+```shell
+kubectl patch featuregate cluster --type='merge' -p '{"spec":{"featureSet":"TechPreviewNoUpgrade"}}' 
+```
+
+Then, from the root directory, create/apply the various API objects defined in the YAML files in the `./examples` directory.
 There are two examples there, where both use [the same namespace](../examples/00-namespace.yaml).
 
 This document describes the [OpenShift Builds with Red Hat Entitlements](../examples/build-with-rhel-entitlements) example.

--- a/docs/simple-example.md
+++ b/docs/simple-example.md
@@ -1,6 +1,14 @@
 # Simple Example
 
-From the root directory, create/apply the various API objects defined in the YAML files in the `./examples` directory.
+As noted in this repositories [main README](../README.md#getting-started), Shared Resources are currently only available
+on 'TechPreviewNoUpgrade' clusters.  So, unless you are employing [local development](../README.md#local-development)
+you can convert your cluster to Tech Preview via:
+
+```shell
+kubectl patch featuregate cluster --type='merge' -p '{"spec":{"featureSet":"TechPreviewNoUpgrade"}}' 
+```
+
+Then, from the root directory, create/apply the various API objects defined in the YAML files in the `./examples` directory.
 There are two examples there, where both use [the same namespace](../examples/00-namespace.yaml).
 
 This document describes the [simple Pod example](../examples/simple).
@@ -14,6 +22,10 @@ To run this example, execute:
 ```shell
 $ kubectl apply -R -f ./examples
 ```
+
+NOTE: if you are running against a cluster with some form of `Pod` security, and you as a user do not have permissions to 
+use `Volumes` of type `csi`, nor does the `ServiceAccount` of the `Pod` (`default` with our example at this time), 
+the creation of the test `Pod` will be rejected.
 
 Ensure the `my-csi-app` Pod comes up in `Running` state.
 
@@ -37,11 +49,6 @@ lrwxrwxrwx    1 root     root            11 Apr 14 14:37 key1 -> ..data/key1
 lrwxrwxrwx    1 root     root            11 Apr 14 14:37 key2 -> ..data/key2
 / # 
 ```
-
-**NOTE**: You'll notice that the driver has created subdirectories off of the `volumeMount` specified in our example `Pod`.
-One subdirectory for the type (`configsmaps` or `secrets`), and one whose name is a concatenation of the `namespace` and
-`name` of the `ConfigMap` or `Secret` being mounted.  As noted in the high level feature list above, new features that allow
-some control on how the files are laid out should be coming.
 
 Now, if you inspect the contents of that `ConfigMap`, you'll see keys in the `data` map that
 correspond to the 2 files created:

--- a/docs/tekton-example.md
+++ b/docs/tekton-example.md
@@ -1,0 +1,62 @@
+# Tekton Example
+
+As noted in this repositories [main README](../README.md#getting-started), Shared Resources are currently only available
+on 'TechPreviewNoUpgrade' clusters.  So, unless you are employing [local development](../README.md#local-development)
+you can convert your cluster to Tech Preview via:
+
+```shell
+kubectl patch featuregate cluster --type='merge' -p '{"spec":{"featureSet":"TechPreviewNoUpgrade"}}' 
+```
+
+Then, from the root directory, create/apply the various API objects defined in the YAML files in the `./examples` directory.
+There are two examples there, where both use [the same namespace](../examples/00-namespace.yaml).
+
+This document describes the [Tekton example](../examples/tekton).
+
+For help on how to install the OpenShift Tekton offering, OpenShift Pipelies, look [here](https://docs.openshift.com/container-platform/4.10/cicd/pipelines/installing-pipelines.html).
+
+This example includes `Task` and `TaskRun` [Tekton](https://github.com/tektoncd/pipeline) instances to leverage a mounted `SharedSecret`.
+There are also various RBAC definitions that allow both
+- the mounting of the `SharedSecret` specifically
+- the use of `Volumes` of the `csi` type, if some form of Pod security is active on your cluster (since the Tekton controller
+is the 'user' that creates the `Pod` from the `TaskRun`, we have to add permissions to use `csi` typed `Volumes` to the 
+`ServiceAccount` of the `TaskRun`)
+ 
+To run this example, execute:
+
+```shell
+$ kubectl apply -R -f ./examples
+```
+
+NOTE: if you are running against a cluster with some form of `Pod` security, and you as a user do not have permissions to 
+use `Volumes` of type `csi`, nor does the `ServiceAccount` of the `Pod` (`default` with our example at this time), 
+the creation of the test `Pod` will be rejected.
+
+Ensure the `my-csi-app` Pod comes up in `Running` state.
+
+Then, if you want to validate the volume, inspect the application pod `my-csi-app-pod`.
+
+To verify, go back into the `TaskRun` named `my-csi-app-pod` and check the logs with the Tekton CLI `tkn`:
+
+```shell
+$ tkn taskrun logs -f my-taskrun-volume
+````
+
+You should see output like:
+
+```shell
+[list] total 0
+[list] drwxrwxrwt. 3 root root 120 Apr 29 17:57 .
+[list] dr-xr-xr-x. 1 root root  99 Apr 29 17:57 ..
+[list] drwxr-xr-x. 2 root root  80 Apr 29 17:57 ..2022_04_29_17_57_36.1098027060
+[list] lrwxrwxrwx. 1 root root  32 Apr 29 17:57 ..data -> ..2022_04_29_17_57_36.1098027060
+[list] lrwxrwxrwx. 1 root root  11 Apr 29 17:57 key1 -> ..data/key1
+[list] lrwxrwxrwx. 1 root root  11 Apr 29 17:57 key2 -> ..data/key2
+
+[show-cannot-update] /tekton/scripts/script-1-lngp7: line 3: /data/foo: Read-only file system
+```
+
+How `Secrets` and `ConfigMaps` are stored on disk mirror the storage for
+`Secrets` and `ConfigMaps` as done in the code in  [https://github.com/kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+where a file is created for each key in a `ConfigMap` `data` map or `binaryData` map and each key in a `Secret`
+`data` map.

--- a/examples/tekton/01-clusterrole-privileged.yaml
+++ b/examples/tekton/01-clusterrole-privileged.yaml
@@ -1,0 +1,11 @@
+# When https://issues.redhat.com/browse/STOR-828 is implemented in OpenShift, and the Shared Resource CSI Driver can be
+# deemed safe for restricted users, this ClusterRole and its associated binding can be removed.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: my-shared-resource-privileged-role
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["my-csi-scc-from-restricted"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]

--- a/examples/tekton/01-clusterrolebinding-privileged.yaml
+++ b/examples/tekton/01-clusterrolebinding-privileged.yaml
@@ -1,0 +1,14 @@
+# When https://issues.redhat.com/browse/STOR-828 is implemented in OpenShift, and the Shared Resource CSI Driver can be
+# deemed safe for restricted users, the referenced ClusterRole and these bindings can be removed.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: shared-resource-node-privileged-binding-default
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: my-csi-app-namespace
+roleRef:
+  kind: ClusterRole
+  name: my-shared-resource-privileged-role
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/tekton/01-role-share.yaml
+++ b/examples/tekton/01-role-share.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shared-resource-my-share-tekton
+  namespace: my-csi-app-namespace
+rules:
+  - apiGroups:
+      - sharedresource.openshift.io
+    resources:
+      - sharedsecrets
+    resourceNames:
+      - my-share-tekton
+    verbs:
+      - use

--- a/examples/tekton/01-rolebinding-share.yaml
+++ b/examples/tekton/01-rolebinding-share.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: shared-resource-my-share-tekton-default
+  namespace: my-csi-app-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: shared-resource-my-share-tekton
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: my-csi-app-namespace

--- a/examples/tekton/01-scc-csi-volumes.yaml
+++ b/examples/tekton/01-scc-csi-volumes.yaml
@@ -1,0 +1,46 @@
+# this is a copy of the "restricted" SCC from openshift, but adds the "csi" volume type
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    kubernetes.io/description: restricted denies access to all host features and requires
+      pods to be run with a UID, and SELinux context that are allocated to the namespace.
+    release.openshift.io/create-only: "true"
+  name: my-csi-scc-from-restricted
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- csi
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/examples/tekton/02-csi-share-tekton.yaml
+++ b/examples/tekton/02-csi-share-tekton.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: my-share-tekton
+spec:
+  secretRef:
+    name: my-secret
+    namespace: my-csi-app-namespace

--- a/examples/tekton/02-secret.yaml
+++ b/examples/tekton/02-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: my-csi-app-namespace
+stringData:
+  key1: secret1
+  key2: secret2

--- a/examples/tekton/03-task-volume.yaml
+++ b/examples/tekton/03-task-volume.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: my-task-volume
+  namespace: my-csi-app-namespace
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+spec:
+  description: >-
+    Demonstrate use of Shared Resource CSI Driver from Tekton
+  steps:
+    - name: list
+      image: registry.redhat.io/ubi8/ubi
+      script: |
+        ls -la /data
+      volumeMounts:
+        - name: my-shared-resource-volume
+          mountPath: /data
+    - name: show-cannot-update
+      image: registry.redhat.io/ubi8/ubi
+      script: |
+        echo "foo" > /data/foo || true
+      volumeMounts:
+        - name: my-shared-resource-volume
+          mountPath: /data
+  volumes:
+    - name: my-shared-resource-volume
+      csi:
+        readOnly: true
+        driver: csi.sharedresource.openshift.io
+        volumeAttributes:
+          sharedSecret: my-share-tekton

--- a/examples/tekton/04-taskrun-volume.yaml
+++ b/examples/tekton/04-taskrun-volume.yaml
@@ -1,0 +1,9 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: my-taskrun-volume
+  namespace: my-csi-app-namespace
+spec:
+  serviceAccountName: default
+  taskRef:
+    name: my-task-volume


### PR DESCRIPTION
The tekton example was one I had on my queue, based on some early pipeline service discussions I had, and then was accelerated by some conference calls today, as well as https://coreos.slack.com/archives/C02FTKEMBU1/p1651237549248689 from @sbose78 

@vdemeester @Michkov FYI

per the slack thread above, once the particulars needed for this work are understood here, the next step per @sbose78 is replicating this somewhere under https://github.com/redhat-appstudio/build-definitions/tree/main/pipelines/base

the use case first was cited by @sbose78 in https://github.com/redhat-appstudio/application-service/pull/65