### PR TITLE
csi topology is only PV relatead, do not need

### DIFF
--- a/pkg/csidriver/nodeserver.go
+++ b/pkg/csidriver/nodeserver.go
@@ -314,14 +314,9 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 
-	topology := &csi.Topology{
-		Segments: map[string]string{TopologyKeyNode: ns.nodeID},
-	}
-
 	return &csi.NodeGetInfoResponse{
 		NodeId:             ns.nodeID,
 		MaxVolumesPerNode:  ns.maxVolumesPerNode,
-		AccessibleTopology: topology,
 	}, nil
 }
 


### PR DESCRIPTION
via an initial conversation with @elmiko and then a joint conversation with him, @jsafrane and @coreydaley (https://coreos.slack.com/archives/CBQHQFU0N/p1661804153262309) discovered that our initial bootstrap of shared resource from the upstream hostpath/shared secret projects left an element of CSI PV support, which of course is not needed with shared resource since it is inline ephemeral only.

cleaning up with this PR

Lastly, since shared resource is tech preview only, my guess is backporting to 4.10.x is not super critical, but since I'm no longer on openshift, I'll defer to @coreydaley and @elmiko to sort that out.