### PR TITLE
BUILD-407: reserve share names starting with openshift part one (code, unit test)

### DIFF
--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var (
+	shutdownSignals      = []os.Signal{os.Interrupt, syscall.SIGTERM}
+	onlyOneSignalHandler = make(chan struct{})
+)
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() (stopCh <-chan struct{}) {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}

--- a/pkg/config/namewatcher.go
+++ b/pkg/config/namewatcher.go
@@ -22,10 +22,10 @@ func SetupNameReservation() *ReservedNames {
 	rn := &ReservedNames{}
 	sharedSecretReservations := os.Getenv(sharedSecretReservedNamesEnvVarName)
 	rn.currentSecretNames = parseEnvVar(sharedSecretReservations, sharedSecretReservedNamesEnvVarName)
-	klog.Infof("reserved shared secret env %s and map %#v", sharedSecretReservations, rn.currentSecretNames)
+	klog.Infof("Loaded reserved shared secret from environment variable %s and data %#v", sharedSecretReservations, rn.currentSecretNames)
 	sharedConfigMapReservations := os.Getenv(sharedConfigMapReservedNamesEnvVarName)
 	rn.currentConfigMapNames = parseEnvVar(sharedConfigMapReservations, sharedConfigMapReservedNamesEnvVarName)
-	klog.Infof("reserved shared configmap env %s and map %#v", sharedConfigMapReservations, rn.currentConfigMapNames)
+	klog.Infof("Loaded reserved shared configmap information from environment variable %s and data %#v", sharedConfigMapReservations, rn.currentConfigMapNames)
 	return rn
 }
 
@@ -34,7 +34,7 @@ func parseEnvVar(val, envvarName string) map[string]types.NamespacedName {
 	entries := strings.Split(val, ";")
 	for _, entry := range entries {
 		a := strings.Split(entry, ":")
-		if len(a) < 3 {
+		if len(a) != 3 {
 			if len(entry) > 0 {
 				klog.Warningf("env var %s has bad entry %s", envvarName, entry)
 			}
@@ -60,8 +60,7 @@ func (rn *ReservedNames) ValidateSharedConfigMapOpenShiftName(shareName, refName
 }
 
 func startsWithOpenShift(shareName string) bool {
-	if strings.HasPrefix(shareName, "openshift-") ||
-		strings.HasPrefix(shareName, "openshift_") {
+	if strings.HasPrefix(shareName, "openshift") {
 		return true
 	}
 	return false

--- a/pkg/config/namewatcher.go
+++ b/pkg/config/namewatcher.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+const (
+	sharedSecretReservedNamesEnvVarName    = "RESERVED_SHARED_SECRET_NAMES"
+	sharedConfigMapReservedNamesEnvVarName = "RESERVED_SHARED_CONFIGMAP_NAMES"
+)
+
+type ReservedNames struct {
+	currentSecretNames    map[string]types.NamespacedName
+	currentConfigMapNames map[string]types.NamespacedName
+}
+
+func SetupNameReservation() *ReservedNames {
+	rn := &ReservedNames{}
+	sharedSecretReservations := os.Getenv(sharedSecretReservedNamesEnvVarName)
+	rn.currentSecretNames = parseEnvVar(sharedSecretReservations, sharedSecretReservedNamesEnvVarName)
+	klog.Infof("reserved shared secret env %s and map %#v", sharedSecretReservations, rn.currentSecretNames)
+	sharedConfigMapReservations := os.Getenv(sharedConfigMapReservedNamesEnvVarName)
+	rn.currentConfigMapNames = parseEnvVar(sharedConfigMapReservations, sharedConfigMapReservedNamesEnvVarName)
+	klog.Infof("reserved shared configmap env %s and map %#v", sharedConfigMapReservations, rn.currentConfigMapNames)
+	return rn
+}
+
+func parseEnvVar(val, envvarName string) map[string]types.NamespacedName {
+	ret := map[string]types.NamespacedName{}
+	entries := strings.Split(val, ";")
+	for _, entry := range entries {
+		a := strings.Split(entry, ":")
+		if len(a) < 3 {
+			if len(entry) > 0 {
+				klog.Warningf("env var %s has bad entry %s", envvarName, entry)
+			}
+			continue
+		}
+		nsName := types.NamespacedName{
+			Namespace: strings.TrimSpace(a[1]),
+			Name:      strings.TrimSpace(a[2]),
+		}
+		ret[strings.TrimSpace(a[0])] = nsName
+	}
+	return ret
+}
+
+func (rn *ReservedNames) ValidateSharedSecretOpenShiftName(shareName, refNamespace, refName string) bool {
+	v, ok := rn.currentSecretNames[shareName]
+	return innerValidate(shareName, refNamespace, refName, ok, v)
+}
+
+func (rn *ReservedNames) ValidateSharedConfigMapOpenShiftName(shareName, refNamespace, refName string) bool {
+	v, ok := rn.currentConfigMapNames[shareName]
+	return innerValidate(shareName, refNamespace, refName, ok, v)
+}
+
+func startsWithOpenShift(shareName string) bool {
+	if strings.HasPrefix(shareName, "openshift-") ||
+		strings.HasPrefix(shareName, "openshift_") {
+		return true
+	}
+	return false
+}
+
+func innerValidate(shareName, refNamespace, refName string, ok bool, v types.NamespacedName) bool {
+	if !startsWithOpenShift(shareName) {
+		return true
+	}
+	if !ok {
+		return false
+	}
+	if strings.TrimSpace(v.Namespace) != strings.TrimSpace(refNamespace) ||
+		strings.TrimSpace(v.Name) != strings.TrimSpace(refName) {
+		return false
+	}
+	return true
+
+}

--- a/pkg/config/namewatcher_test.go
+++ b/pkg/config/namewatcher_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestValidateSharedSecretOpenShiftName(t *testing.T) {
+
+	for _, test := range []struct {
+		name         string
+		shareName    string
+		refNamespace string
+		refName      string
+		envVarValue  string
+		valid        bool
+	}{
+		{
+			name:         "non openshift",
+			shareName:    "anyshare",
+			refNamespace: "foo",
+			refName:      "bar",
+			valid:        true,
+		},
+		{
+			name:         "openshift that is not present",
+			shareName:    "openshift-anyshare",
+			refNamespace: "foo",
+			refName:      "bar",
+			valid:        false,
+		},
+		{
+			name:         "openshift that is present but incorrect",
+			shareName:    "openshift-anyshare",
+			refNamespace: "fee",
+			refName:      "bee",
+			envVarValue:  "openshift-anyshare: foo:bar",
+		},
+		{
+			name:         "openshift that is present and correct",
+			shareName:    "openshift-anyshare",
+			refNamespace: "foo",
+			refName:      "bar",
+			envVarValue:  "openshift-anyshare: foo:bar",
+			valid:        true,
+		},
+	} {
+		if len(test.envVarValue) > 0 {
+			os.Setenv(sharedSecretReservedNamesEnvVarName, test.envVarValue)
+		}
+		rn := SetupNameReservation()
+		if test.valid != rn.ValidateSharedSecretOpenShiftName(test.shareName, test.refNamespace, test.refName) {
+			t.Errorf("test %s did not provide validity of %v", test.name, test.valid)
+		}
+	}
+}
+
+func TestValidateSharedConfigMapOpenShiftName(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		shareName    string
+		refNamespace string
+		refName      string
+		envVarValue  string
+		valid        bool
+	}{
+		{
+			name:         "non openshift",
+			shareName:    "anyshare",
+			refNamespace: "foo",
+			refName:      "bar",
+			valid:        true,
+		},
+		{
+			name:         "openshift that is not present",
+			shareName:    "openshift-anyshare",
+			refNamespace: "foo",
+			refName:      "bar",
+			valid:        false,
+		},
+		{
+			name:         "openshift that is present but incorrect",
+			shareName:    "openshift-anyshare",
+			refNamespace: "fee",
+			refName:      "bee",
+			envVarValue:  "openshift-anyshare: foo:bar",
+		},
+		{
+			name:         "openshift that is present and correct",
+			shareName:    "openshift-anyshare",
+			refNamespace: "foo",
+			refName:      "bar",
+			envVarValue:  "openshift-anyshare: foo:bar",
+			valid:        true,
+		},
+	} {
+		if len(test.envVarValue) > 0 {
+			os.Setenv(sharedConfigMapReservedNamesEnvVarName, test.envVarValue)
+		}
+		rn := SetupNameReservation()
+		if test.valid != rn.ValidateSharedConfigMapOpenShiftName(test.shareName, test.refNamespace, test.refName) {
+			t.Errorf("test %s did not provide validity of %v", test.name, test.valid)
+		}
+	}
+
+}

--- a/pkg/config/namewatcher_test.go
+++ b/pkg/config/namewatcher_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"testing"
 )
@@ -35,6 +36,7 @@ func TestValidateSharedSecretOpenShiftName(t *testing.T) {
 			refNamespace: "fee",
 			refName:      "bee",
 			envVarValue:  "openshift-anyshare: foo:bar",
+			valid:        false,
 		},
 		{
 			name:         "openshift that is present and correct",
@@ -103,4 +105,131 @@ func TestValidateSharedConfigMapOpenShiftName(t *testing.T) {
 		}
 	}
 
+}
+
+func TestParseEnvVar(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		envVarValue string
+		expectedMap map[string]types.NamespacedName
+	}{
+		{
+			name:        "empty",
+			envVarValue: "",
+			expectedMap: map[string]types.NamespacedName{},
+		},
+		{
+			name:        "one entry",
+			envVarValue: "openshift-foo: foo:bar",
+			expectedMap: map[string]types.NamespacedName{
+				"openshift-foo": {
+					Namespace: "foo",
+					Name:      "bar",
+				},
+			},
+		},
+		{
+			name:        "two entries",
+			envVarValue: "openshift-foo: foo:bar; openshift-bar: bar:foo",
+			expectedMap: map[string]types.NamespacedName{
+				"openshift-foo": {
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				"openshift-bar": {
+					Namespace: "bar",
+					Name:      "foo",
+				},
+			},
+		},
+		{
+			name:        "bad one entry",
+			envVarValue: "openshift-foo: ",
+			expectedMap: map[string]types.NamespacedName{},
+		},
+		{
+			name:        "bad two entries",
+			envVarValue: "openshift-foo: foo:bar, openshift-bar: bar:foo",
+			expectedMap: map[string]types.NamespacedName{},
+		},
+	} {
+		retMap := parseEnvVar(test.envVarValue, "")
+		if len(retMap) != len(test.expectedMap) {
+			t.Errorf("test %s envVarValue %s got map %#v with different number of entries than %s",
+				test.name,
+				test.envVarValue,
+				retMap,
+				test.expectedMap)
+			continue
+		}
+		for key, nsName := range test.expectedMap {
+			v, ok := retMap[key]
+			if !ok {
+				t.Errorf("test %s envVarValue %s return map %s missing key %s",
+					test.name,
+					test.envVarValue,
+					retMap,
+					key)
+				continue
+			}
+			if nsName.String() != v.String() {
+				t.Errorf("test %s envVarValue %s return map %s key %s had value %s instead of %s",
+					test.name,
+					test.envVarValue,
+					retMap,
+					key,
+					v,
+					nsName)
+				continue
+			}
+		}
+	}
+}
+
+func TestStartsWithOpenshift(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "non-openshift",
+			input:    "foo",
+			expected: false,
+		},
+		{
+			name:     "openshift hyphen",
+			input:    "openshift-foo",
+			expected: true,
+		},
+		{
+			name:     "openshift underscore",
+			input:    "openshift_foo",
+			expected: true,
+		},
+		{
+			name:     "just openshift",
+			input:    "openshift",
+			expected: true,
+		},
+		{
+			name:     "case sensitive",
+			input:    "OpenShift",
+			expected: false,
+		},
+	} {
+		output := startsWithOpenShift(test.input)
+		if output != test.expected {
+			t.Errorf("test %s with input %s got %v instead of %v",
+				test.name,
+				test.input,
+				output,
+				test.expected)
+		}
+	}
 }

--- a/pkg/csidriver/driver.go
+++ b/pkg/csidriver/driver.go
@@ -104,7 +104,7 @@ type CSIDriver interface {
 	deleteVolume(volID string) error
 	getVolumePath(volID string, volCtx map[string]string) (string, string)
 	mapVolumeToPod(dv *driverVolume) error
-	Run()
+	Run(rn *config.ReservedNames)
 	GetRoot() string
 	GetVolMapRoot() string
 	Prune(kubeClient kubernetes.Interface)
@@ -170,13 +170,13 @@ func (d *driver) GetVolMapRoot() string {
 	return d.volMapRoot
 }
 
-func (d *driver) Run() {
+func (d *driver) Run(rn *config.ReservedNames) {
 	// Create GRPC servers
 	d.ids = NewIdentityServer(d.name, d.version)
 
 	// the node-server will be on always-read-only mode when the object-cache is being populated
 	// directly
-	d.ns = NewNodeServer(d)
+	d.ns = NewNodeServer(d, rn)
 
 	s := NewNonBlockingGRPCServer()
 	s.Start(d.endpoint, d.ids, d.ns)

--- a/pkg/csidriver/nodeserver_test.go
+++ b/pkg/csidriver/nodeserver_test.go
@@ -67,9 +67,6 @@ func testNodeServer(testName string) (*nodeServer, string, string, error) {
 	if err != nil {
 		return nil, "", "", err
 	}
-	if err != nil {
-		return nil, "", "", err
-	}
 	ns := &nodeServer{
 		nodeID:            "node1",
 		maxVolumesPerNode: 0,

--- a/pkg/webhook/csidriver/csidriver.go
+++ b/pkg/webhook/csidriver/csidriver.go
@@ -1,9 +1,13 @@
 package csidriver
 
 import (
+	"fmt"
 	"net/http"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	sharev1alpha1 "github.com/openshift/api/sharedresource/v1alpha1"
+	"github.com/openshift/csi-driver-shared-resource/pkg/config"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -32,11 +36,12 @@ type Webhook interface {
 
 // SharedResourcesCSIDriverWebhook validates a Shared Resources CSI Driver change
 type SharedResourcesCSIDriverWebhook struct {
+	rn *config.ReservedNames
 }
 
 // NewWebhook creates a new webhook
-func NewWebhook() *SharedResourcesCSIDriverWebhook {
-	return &SharedResourcesCSIDriverWebhook{}
+func NewWebhook(rn *config.ReservedNames) *SharedResourcesCSIDriverWebhook {
+	return &SharedResourcesCSIDriverWebhook{rn: rn}
 }
 
 // GetURI implements Webhook interface
@@ -47,23 +52,38 @@ func (s *SharedResourcesCSIDriverWebhook) Name() string { return WebhookName }
 
 // Validate if the incoming request even valid
 func (s *SharedResourcesCSIDriverWebhook) Validate(req admissionctl.Request) bool {
-	return req.Kind.Kind == "Pod"
+	return req.Kind.Kind == "Pod" || req.Kind.Kind == "SharedSecret" || req.Kind.Kind == "SharedConfigMap"
 }
 
 // Authorized implements Webhook interface
 func (s *SharedResourcesCSIDriverWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
-	return s.authorizePod(request)
+	pod, perr := s.renderPod(request)
+	ss, sserr := s.renderSharedSecret(request)
+	sc, scerr := s.renderSharedConfigMap(request)
+
+	if perr != nil && sserr != nil && scerr != nil {
+		klog.Error(perr, "Couldn't render a Pod from the incoming request")
+		klog.Error(sserr, "Couldn't render a SharedSecret from the incoming request")
+		klog.Error(scerr, "Couldn't render a SharedConfigMap from the incoming request")
+		return admissionctl.Errored(http.StatusBadRequest, perr)
+	}
+
+	switch {
+	case pod != nil && perr == nil:
+		return s.authorizePod(request, pod)
+	case ss != nil && sserr == nil:
+		return s.authorizeSharedSecret(request, ss)
+	case sc != nil && scerr == nil:
+		return s.authorizeSharedConfigMap(request, sc)
+	}
+	ret := admissionctl.Allowed("type we are unconcerned with")
+	ret.UID = request.AdmissionRequest.UID
+	return ret
 }
 
-func (s *SharedResourcesCSIDriverWebhook) authorizePod(request admissionctl.Request) admissionctl.Response {
+func (s *SharedResourcesCSIDriverWebhook) authorizePod(request admissionctl.Request, pod *corev1.Pod) admissionctl.Response {
 	klog.V(2).Info("admitting pod with SharedResourceCSIVolume")
 	var ret admissionctl.Response
-
-	pod, err := s.renderPod(request)
-	if err != nil {
-		klog.Error(err, "Couldn't render a Pod from the incoming request")
-		return admissionctl.Errored(http.StatusBadRequest, err)
-	}
 
 	for _, volume := range pod.Spec.Volumes {
 		if volume.VolumeSource.CSI != nil &&
@@ -79,6 +99,35 @@ func (s *SharedResourcesCSIDriverWebhook) authorizePod(request admissionctl.Requ
 	ret = admissionctl.Allowed("Allowed to create Pod")
 	ret.UID = request.AdmissionRequest.UID
 	return ret
+}
+
+func (s *SharedResourcesCSIDriverWebhook) authorizeSharedSecret(request admissionctl.Request, ss *sharev1alpha1.SharedSecret) admissionctl.Response {
+	klog.V(2).Info("admitting shared secret with SharedResourceCSIVolume")
+	var ret admissionctl.Response
+
+	if s.rn.ValidateSharedSecretOpenShiftName(ss.Name, ss.Spec.SecretRef.Namespace, ss.Spec.SecretRef.Name) {
+		ret = admissionctl.Allowed("Allowed to create SharedSecret")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+	ret = admissionctl.Denied(fmt.Sprintf("Not allowed to create SharedSecret with name %s as it violates the reserved names list", ss.Name))
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+func (s *SharedResourcesCSIDriverWebhook) authorizeSharedConfigMap(request admissionctl.Request, scm *sharev1alpha1.SharedConfigMap) admissionctl.Response {
+	klog.V(2).Info("admitting shared configmap with SharedResourceCSIVolume")
+	var ret admissionctl.Response
+
+	if s.rn.ValidateSharedConfigMapOpenShiftName(scm.Name, scm.Spec.ConfigMapRef.Namespace, scm.Spec.ConfigMapRef.Name) {
+		ret = admissionctl.Allowed("Allowed to create SharedConfigMap")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+	ret = admissionctl.Denied(fmt.Sprintf("Not allowed to create SharedConfigMap with name %s as it violates the reserved names list", scm.Name))
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+
 }
 
 // renderPod decodes an *corev1.Pod from the incoming request.
@@ -97,4 +146,34 @@ func (s *SharedResourcesCSIDriverWebhook) renderPod(request admissionctl.Request
 	}
 
 	return pod, err
+}
+
+func (s *SharedResourcesCSIDriverWebhook) renderSharedSecret(request admissionctl.Request) (*sharev1alpha1.SharedSecret, error) {
+	decoder, err := admissionctl.NewDecoder(scheme)
+	if err != nil {
+		return nil, err
+	}
+	sharedSecret := &sharev1alpha1.SharedSecret{}
+	if len(request.OldObject.Raw) > 0 {
+		err = decoder.DecodeRaw(request.OldObject, sharedSecret)
+	} else {
+		err = decoder.DecodeRaw(request.Object, sharedSecret)
+	}
+
+	return sharedSecret, err
+}
+
+func (s *SharedResourcesCSIDriverWebhook) renderSharedConfigMap(request admissionctl.Request) (*sharev1alpha1.SharedConfigMap, error) {
+	decoder, err := admissionctl.NewDecoder(scheme)
+	if err != nil {
+		return nil, err
+	}
+	sharedConfigMap := &sharev1alpha1.SharedConfigMap{}
+	if len(request.OldObject.Raw) > 0 {
+		err = decoder.DecodeRaw(request.OldObject, sharedConfigMap)
+	} else {
+		err = decoder.DecodeRaw(request.Object, sharedConfigMap)
+	}
+
+	return sharedConfigMap, err
 }

--- a/pkg/webhook/csidriver/csidriver_test.go
+++ b/pkg/webhook/csidriver/csidriver_test.go
@@ -126,7 +126,7 @@ func TestAuthorize(t *testing.T) {
 			Operation: tc.operation,
 		}
 
-		hook := NewWebhook()
+		hook := NewWebhook(nil)
 		req := admissionctl.Request{
 			AdmissionRequest: Request,
 		}

--- a/test/e2e/normal_test.go
+++ b/test/e2e/normal_test.go
@@ -101,6 +101,31 @@ func TestRejectPodWithReadOnlyFalseSharedVolume(t *testing.T) {
 	framework.CreateTestPod(testArgs)
 }
 
+func TestRejectShareWithOpenShiftPrefix(t *testing.T) {
+	testArgs := &framework.TestArgs{
+		T:                       t,
+		ShareNameOverride:       "openshift-foo",
+		TestShareCreateRejected: true,
+	}
+	prep(testArgs)
+	framework.CreateTestNamespace(testArgs)
+	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
+	framework.CreateShareRelatedRBAC(testArgs)
+	framework.CreateShare(testArgs)
+}
+
+func TestAcceptShareWithOpenShiftPrefix(t *testing.T) {
+	testArgs := &framework.TestArgs{
+		T:                 t,
+		ShareNameOverride: "openshift-etc-pki-entitlement",
+	}
+	prep(testArgs)
+	framework.CreateTestNamespace(testArgs)
+	defer framework.CleanupTestNamespaceAndClusterScopedResources(testArgs)
+	framework.CreateShareRelatedRBAC(testArgs)
+	framework.CreateReservedOpenShiftShare(testArgs)
+}
+
 /* a consequence of read only volume mounts is that we no longer support inherited mount paths
 across separate shares in that mode.  The sub path mount encounters read only file system errors.
 

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -54,11 +54,25 @@ func CleanupTestNamespaceAndClusterScopedResources(t *TestArgs) {
 	}
 	err = shareClient.SharedresourceV1alpha1().SharedSecrets().Delete(context.TODO(), t.SecondName, metav1.DeleteOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
-		t.T.Fatalf("error deleting share %s: %s", t.Name, err.Error())
+		t.T.Fatalf("error deleting share %s: %s", t.SecondName, err.Error())
 	}
 	err = shareClient.SharedresourceV1alpha1().SharedConfigMaps().Delete(context.TODO(), t.SecondName, metav1.DeleteOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
-		t.T.Fatalf("error deleting share %s: %s", t.Name, err.Error())
+		t.T.Fatalf("error deleting share %s: %s", t.SecondName, err.Error())
+	}
+	if len(t.ShareNameOverride) > 0 {
+		err = shareClient.SharedresourceV1alpha1().SharedSecrets().Delete(context.TODO(), t.ShareNameOverride, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			t.T.Fatalf("error deleting share %s: %s", t.ShareNameOverride, err.Error())
+		}
+		err = shareClient.SharedresourceV1alpha1().SharedConfigMaps().Delete(context.TODO(), t.ShareNameOverride, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			t.T.Fatalf("error deleting share %s: %s", t.ShareNameOverride, err.Error())
+		}
+	}
+	err = shareClient.SharedresourceV1alpha1().SharedSecrets().Delete(context.TODO(), "openshift-etc-pki-entitlement", metav1.DeleteOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		t.T.Fatalf("error deleting share openshift-etc-pki-entitlement: %s", err.Error())
 	}
 	// try to clean up pods in test namespace individually to avoid weird k8s timing issues
 	podList, _ := kubeClient.CoreV1().Pods(t.Name).List(context.TODO(), metav1.ListOptions{})

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -28,6 +28,17 @@ const (
 
 func CreateTestPod(t *TestArgs) {
 	t.T.Logf("%s: start create test pod %s", time.Now().String(), t.Name)
+	saErr := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		_, e := kubeClient.CoreV1().ServiceAccounts(t.Name).Get(context.TODO(), "default", metav1.GetOptions{})
+		if e != nil {
+			t.T.Logf("default SA not available yet: %s", e.Error())
+			return false, nil
+		}
+		return true, nil
+	})
+	if saErr != nil {
+		t.T.Logf("default SA for namespace %s not available ever after a minute from namespace creation", t.Name)
+	}
 	truVal := true
 	falVal := false
 	pod := &corev1.Pod{

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -14,6 +14,7 @@ var (
 type TestArgs struct {
 	T                                  *testing.T
 	Name                               string
+	ShareNameOverride                  string
 	SecondName                         string
 	ChangeName                         string
 	SearchString                       string
@@ -30,6 +31,7 @@ type TestArgs struct {
 	TestPodUp                          bool
 	NoRefresh                          bool
 	TestReadOnly                       bool
+	TestShareCreateRejected            bool
 	TestDuration                       time.Duration
 }
 


### PR DESCRIPTION
/assign @coreydaley 

So this reworks / replaces https://github.com/openshift/csi-driver-shared-resource/pull/109

Major notes:
- no e2e tests yet, only unit tests, as we cannot make the changes to the webhook config to start processing creates of `SharedSecrets` and `SharedConfigMaps` without operator changes at https://github.com/openshift/csi-driver-shared-resource-operator/blob/master/assets/webhook/validating_webhook_configuration.yaml ; so I want to minimize the demands on the operator e2e and avoid the chicken/egg testing scenarios we had last time; I'll update the operator after this passes regression and merges here; then once the webhook config is ready, along with the shared resource for build entitlements, we can test and validate acceptance of blesshed its functionality with the full e2e's here in a follow up PR
- I pivoted form the mount the config map in the driver approach; a couple of reasons for that:  a) simplicity / helps with chicken/egg testing; b) it will give us some flexibility down the line if we want to install this as part of other devtools items not based on OCP, c) envar lookup is cheaper that access the file system or api calls 


I have not run e2e locally yet, *thinking* the new unit tests should get me duplicate coverage for the existing cases, but we'll find out soon enough.  

I would defer code review @coreydaley then until the e2e's are at least passing, in case I'm wrong there.