### PR TITLE
OCPBUGS-7272: add version file to must-gather output

### DIFF
--- a/must-gather/gather
+++ b/must-gather/gather
@@ -19,4 +19,11 @@ for pod in "${pods[@]}"; do
   oc rsync -c hostpath -n ${cdsrNamespace} "$pod":/csi-volumes-map ${object_collection_path}/"$pod"
 done
 
+echo "openshift/shared-resources-must-gather" > must-gather/version
+if [[ ! -z $OS_GIT_VERSION ]] ; then
+  echo "${OS_GIT_VERSION}" >> must-gather/version
+else
+  echo "4.13" >> must-gather/version
+fi
+
 exit 0


### PR DESCRIPTION
output from my locally built version of the must-gather image:

```
gmontero ~/Downloads $ cd must-gather.local.953827461968579409/
gmontero ~/Downloads/must-gather.local.953827461968579409 $ ls
event-filter.html  quay-io-gabemontero-origin-csi-driver-shared-resource-mustgather-sha256-1c0fff716033eb0e39ad54baed67678d3f9cd4f243438e3ad1de384e4de57224  timestamp
gmontero ~/Downloads/must-gather.local.953827461968579409 $ cd quay-io-gabemontero-origin-csi-driver-shared-resource-mustgather-sha256-1c0fff716033eb0e39ad54baed67678d3f9cd4f243438e3ad1de384e4de57224/
gmontero ~/Downloads/must-gather.local.953827461968579409/quay-io-gabemontero-origin-csi-driver-shared-resource-mustgather-sha256-1c0fff716033eb0e39ad54baed67678d3f9cd4f243438e3ad1de384e4de57224 $ ls
cluster-scoped-resources  version
gmontero ~/Downloads/must-gather.local.953827461968579409/quay-io-gabemontero-origin-csi-driver-shared-resource-mustgather-sha256-1c0fff716033eb0e39ad54baed67678d3f9cd4f243438e3ad1de384e4de57224 $ cat version
openshift/shared-resources-must-gather
4.13.0-202301031913.p0.gf4ddd28.assembly.stream-f4ddd28
gmontero ~/Downloads/must-gather.local.953827461968579409/quay-io-gabemontero-origin-csi-driver-shared-resource-mustgather-sha256-1c0fff716033eb0e39ad54baed67678d3f9cd4f243438e3ad1de384e4de57224 $ 
```

/assign @coreydaley 
/assign @sferich888 