### PR TITLE
OCPBUGS-27860,OCPBUGS-28261: address SAST/SNYK findings

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,4 +3,8 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    - vendor/**
+    # all yamls, including the pod ones, in our examples directory are simply samples for users trying shared resources out; these artifacts are not created by any of the images
+    - examples/**
+    # this pod.yaml in apimachinery is just another sample that is never created by our images; you'll see it creates the pod "some-name" in the default namespace
+    - vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
+    - unpacked_remote_sources/cachito-gomod-with-deps/app/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
+# to make SAST/SNYK happy
+RUN rm -rf examples
+RUN rm -f vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 COPY . .
+RUN rm -rf /go/src/github.com/openshift/csi-driver-shared-resource/examples
+RUN rm -f /go/src/github.com/openshift/csi-driver-shared-resource/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9

--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,4 +1,7 @@
 FROM registry.ci.openshift.org/ocp/4.16:must-gather
+# to make SAST/SNYK happy
+RUN rm -rf examples
+RUN rm -f vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 COPY must-gather/* /usr/bin/
 RUN chmod +x /usr/bin/gather
 

--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -1,6 +1,11 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
+# to make SAST/SNYK happy
+RUN rm -rf examples
+RUN rm -f vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 COPY . .
+RUN rm -rf /go/src/github.com/openshift/csi-driver-shared-resource/examples
+RUN rm -f /go/src/github.com/openshift/csi-driver-shared-resource/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 RUN make build-webhook
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9


### PR DESCRIPTION
exclude examples, apimachinery samples, from sast/snyk scan
    
None of our examples are items that run in any of the images produced
for shared resources csi driver.  They are simply artifact users can employ
when trying out the system, learning what it can do.
Also, the 'vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml' cited
by the scan is a sample from that component as well.  you'll see it creates the pod "some-name" in the default namespace

However, just in case, we are also removing the files in question in our source tree when building our various images.
