### PR TITLE
BUILD-957: Update Images with Red Hat Catalog Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12 AS builder
 WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
 # to make SAST/SNYK happy
 RUN rm -rf examples
@@ -8,7 +8,7 @@ RUN rm -rf /go/src/github.com/openshift/csi-driver-shared-resource/examples
 RUN rm -f /go/src/github.com/openshift/csi-driver-shared-resource/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.access.redhat.com/ubi9/ubi:9.4
 COPY --from=builder /go/src/github.com/openshift/csi-driver-shared-resource/_output/csi-driver-shared-resource /usr/bin/
 ENTRYPOINT []
 CMD ["/usr/bin/csi-driver-shared-resource"]

--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12 AS builder
 WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
 # to make SAST/SNYK happy
 RUN rm -rf examples
@@ -8,6 +8,6 @@ RUN rm -rf /go/src/github.com/openshift/csi-driver-shared-resource/examples
 RUN rm -f /go/src/github.com/openshift/csi-driver-shared-resource/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 RUN make build-webhook
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.access.redhat.com/ubi9/ubi:9.4
 COPY --from=builder /go/src/github.com/openshift/csi-driver-shared-resource/_output/csi-driver-shared-resource-webhook /usr/bin/
 ENTRYPOINT ["/usr/bin/csi-driver-shared-resource-webhook"]

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(TARGET_GOARCH), amd64)
 	RACE = -race
 endif
 
-GOFLAGS ?= -a -mod=vendor $(RACE)
+GOFLAGS ?= -a -mod=vendor -buildvcs=false $(RACE)
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
- OpenShift CI registry is not available in Konflux and using secret to
  access is not a good idea
- updated Dockerfiles to use Red Hat catalog images: https://catalog.redhat.com/software/containers/explore
- Refer [BUILD-957](https://issues.redhat.com//browse/BUILD-957)

Signed-off-by: Avinal Kumar <avinal@redhat.com>
