### PR TITLE
BUILD-961: use separate dockerfile for using catalog images

### DIFF
--- a/.konflux/cdsr-webhook/Dockerfile
+++ b/.konflux/cdsr-webhook/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12 AS builder
+WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
+COPY . .
+RUN rm -rf /go/src/github.com/openshift/csi-driver-shared-resource/examples
+RUN rm -f /go/src/github.com/openshift/csi-driver-shared-resource/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
+RUN make build-webhook
+
+FROM registry.access.redhat.com/ubi9/ubi:9.4
+COPY --from=builder /go/src/github.com/openshift/csi-driver-shared-resource/_output/csi-driver-shared-resource-webhook /usr/bin/
+ENTRYPOINT ["/usr/bin/csi-driver-shared-resource-webhook"]

--- a/.konflux/cdsr/Dockerfile
+++ b/.konflux/cdsr/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12 AS builder
+WORKDIR /go/src/github.com/openshift/csi-driver-shared-resource
+COPY . .
+RUN rm -rf /go/src/github.com/openshift/csi-driver-shared-resource/examples
+RUN rm -f /go/src/github.com/openshift/csi-driver-shared-resource/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
+RUN make build
+
+FROM registry.access.redhat.com/ubi9/ubi:9.4
+COPY --from=builder /go/src/github.com/openshift/csi-driver-shared-resource/_output/csi-driver-shared-resource /usr/bin/
+ENTRYPOINT []
+CMD ["/usr/bin/csi-driver-shared-resource"]


### PR DESCRIPTION
- Konflux does not support using OpenShift CI images hence use a
  modified dockerfile for Konflux

Signed-off-by: Avinal Kumar <avinal@redhat.com>
