### PR TITLE
fix: Remove image-expires-after parameter from push pipeline

### DIFF
--- a/.tekton/openshift-builds-shared-resource-push.yaml
+++ b/.tekton/openshift-builds-shared-resource-push.yaml
@@ -29,8 +29,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-shared-resource:{{revision}}
-  - name: image-expires-after
-    value: 5d
   - name: dockerfile
     value: .konflux/shared-resource/Dockerfile
   - name: build-source-image

--- a/.tekton/openshift-builds-shared-resource-webhook-push.yaml
+++ b/.tekton/openshift-builds-shared-resource-webhook-push.yaml
@@ -29,8 +29,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-shared-resource-webhook:{{revision}}
-  - name: image-expires-after
-    value: 5d
   - name: dockerfile
     value: .konflux/shared-resource-webhook/Dockerfile
   - name: build-source-image


### PR DESCRIPTION
Changes:
- The image-expires-after parameter is removed as it creates a violation is enterprise contract test.