### PR TITLE
Disable ppc64le and s390x architecture for pull request

### DIFF
--- a/.tekton/openshift-builds-shared-resource-pull-request.yaml
+++ b/.tekton/openshift-builds-shared-resource-pull-request.yaml
@@ -37,6 +37,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-shared-resource-push.yaml
+++ b/.tekton/openshift-builds-shared-resource-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-shared-resource-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-shared-resource-webhook-pull-request.yaml
@@ -37,6 +37,10 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:

--- a/.tekton/openshift-builds-shared-resource-webhook-push.yaml
+++ b/.tekton/openshift-builds-shared-resource-webhook-push.yaml
@@ -35,6 +35,12 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineSpec:


### PR DESCRIPTION
Changes:
- Update tekton pipelines to disable ppc64le and s390x architecture for pull request