### PR TITLE
fix: change image in dockerfile to remove setuptools package

### DIFF
--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-shared-resource ./cmd/csidriver
 
-FROM registry.redhat.io/ubi9@sha256:ea57285741f007e83f2ee20423c20b0cbcce0b59cc3da027c671692cc7efe4dd
+FROM registry.access.redhat.com/ubi9-minimal@sha256:e12131db2e2b6572613589a94b7f615d4ac89d94f859dad05908aeb478fb090f
 
 WORKDIR /
 


### PR DESCRIPTION
In .konflux/shared-resource/Dockerfile
The image we were using had the vulnerable package  (which we are not using)  

The change includes the use of UBI minimal image which doesn't have the setuptools package. 

