### PR TITLE
BUILD-1459: Fixes CVE-2025-47273 by updating UBI image without the setuptools package

### DIFF
--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-shared-resource-webhook ./cmd/webhook
 
-FROM registry.redhat.io/ubi9-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
+FROM registry.access.redhat.com/ubi9-minimal:9.6
 
 WORKDIR /
 

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o openshift-builds-shared-resource ./cmd/csidriver
 
-FROM registry.redhat.io/ubi9@sha256:ea57285741f007e83f2ee20423c20b0cbcce0b59cc3da027c671692cc7efe4dd
+FROM registry.access.redhat.com/ubi9-minimal:9.6
 
 WORKDIR /
 


### PR DESCRIPTION
In .konflux/shared-resource/Dockerfile
The image we were using had the vulnerable package setuptools (which we are not using)

The change includes the use of UBI minimal image which doesn't have the setuptools package.

Fixing CVE: https://github.com/advisories/GHSA-5rjg-fvgr-3xxf

Jira issues it fixes:

https://issues.redhat.com/browse/BUILD-1459
https://issues.redhat.com/browse/BUILD-1461