### PR TITLE
[BUILD-984] Add test to verify RBAC checks

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.20
+  tag: rhel-9-release-golang-1.25-openshift-4.21

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Sharing resources is done as follows:
 
 See also:
 
+- [RBAC configuration](docs/rbac.md)
 - [Simple example](docs/simple-example.md)
 - [Tekton example](docs/tekton-example.md)
 - [OpenShift BuildConfig example](docs/build-with-rhel-entitlements.md)

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,213 @@
+# RBAC Configuration for Shared Resources
+
+The Shared Resource CSI Driver enforces two layers of RBAC before mounting a
+`SharedSecret` or `SharedConfigMap` into a Pod:
+
+1. **Driver-level RBAC** — The CSI driver's ServiceAccount must have
+   `get`, `list`, and `watch` permissions on the source Secret or ConfigMap in
+   its namespace.
+2. **Pod-level RBAC** — The Pod's ServiceAccount must have `use` permission on
+   the `SharedSecret` or `SharedConfigMap` resource.
+
+Both layers must be satisfied. If either is missing, the volume mount fails and
+the Pod stays in a pending state with a `FailedMount` event.
+
+## Prerequisites
+
+- OpenShift cluster with Shared Resource CSI Driver deployed 
+- The CSI driver DaemonSet runs under the `csi-driver-shared-resource`
+  ServiceAccount in the `openshift-builds` namespace 
+
+## Granting Driver Permission to Access the Source Resource
+
+The CSI driver no longer has cluster-wide read access to all Secrets and
+ConfigMaps. You must explicitly grant it permission to read each source
+resource by creating a `Role` and `RoleBinding` in the source namespace.
+
+### For a Secret
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-read-my-secret
+  namespace: source-namespace
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["my-secret"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-read-my-secret
+  namespace: source-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-read-my-secret
+subjects:
+  - kind: ServiceAccount
+    name: csi-driver-shared-resource
+    namespace: openshift-builds
+```
+
+### For a ConfigMap
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-read-my-configmap
+  namespace: source-namespace
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["my-configmap"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-read-my-configmap
+  namespace: source-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-read-my-configmap
+subjects:
+  - kind: ServiceAccount
+    name: csi-driver-shared-resource
+    namespace: openshift-builds
+```
+
+## Granting Pod Permission to Use a Shared Resource
+
+The consuming Pod's ServiceAccount needs the `use` verb on the specific
+`SharedSecret` or `SharedConfigMap`. This is done with a `ClusterRole` (since
+shared resources are cluster-scoped) and a `RoleBinding` in the consuming
+namespace.
+
+### For a SharedSecret
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: use-my-shared-secret
+rules:
+  - apiGroups:
+      - sharedresource.openshift.io
+    resources:
+      - sharedsecrets
+    resourceNames:
+      - my-shared-secret
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: use-my-shared-secret
+  namespace: consuming-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: use-my-shared-secret
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: consuming-namespace
+```
+
+### For a SharedConfigMap
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: use-my-shared-configmap
+rules:
+  - apiGroups:
+      - sharedresource.openshift.io
+    resources:
+      - sharedconfigmaps
+    resourceNames:
+      - my-shared-configmap
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: use-my-shared-configmap
+  namespace: consuming-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: use-my-shared-configmap
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: consuming-namespace
+```
+
+## Complete Examples
+
+For full end-to-end walkthroughs that include all RBAC objects, see:
+
+- [Simple example](simple-example.md) — mounts a `SharedConfigMap` into a Pod
+  ([YAML files](../examples/simple))
+- [Tekton example](tekton-example.md) — mounts a `SharedSecret` into a Tekton
+  TaskRun ([YAML files](../examples/tekton))
+- [README — How To Use](../README.md#how-to-use) — step-by-step with inline
+  YAML covering both driver and pod RBAC
+
+## Troubleshooting
+
+### Mount fails with PermissionDenied
+
+```
+FailedMount: rpc error: code = PermissionDenied desc = subjectaccessreviews
+share <name> podNamespace <ns> podName <pod> podSA <sa> returned forbidden
+```
+
+**Cause:** The Pod's ServiceAccount does not have `use` permission on the
+SharedSecret or SharedConfigMap.
+
+**Fix:** Create or verify the `ClusterRole` and `RoleBinding` granting the `use`
+verb to the Pod's ServiceAccount as shown above.
+
+### Mount fails with "not found" for the backing resource
+
+```
+FailedMount: rpc error: code = Internal desc = failed to populate mount device:
+... secrets "my-secret" not found
+```
+
+**Cause:** The CSI driver's ServiceAccount does not have permission to read the
+source Secret or ConfigMap in its namespace, or the source resource does not
+exist.
+
+**Fix:**
+1. Verify the source Secret/ConfigMap exists in the expected namespace.
+2. Create or verify the `Role` and `RoleBinding` in the source namespace
+   granting the CSI driver ServiceAccount `get`, `list`, `watch` on the
+   specific resource.
+
+### Data disappears from a running Pod
+
+**Cause:** The RBAC permissions were removed after the Pod started. The CSI
+driver periodically re-evaluates permissions (default interval: 10 minutes via
+`shareRelistInterval`) and removes data when access is revoked.
+
+**Fix:** Restore the required `Role`/`RoleBinding`. The data will be
+re-populated on the next relist cycle. See the [FAQ](faq.md) for details.
+
+## Summary
+
+| RBAC Layer | Scope | Resource | Verbs | Purpose |
+|---|---|---|---|---|
+| Driver access | Source namespace | `secrets` or `configmaps` | `get`, `list`, `watch` | Allows the CSI driver to read the source data |
+| Pod access | Consuming namespace | `sharedsecrets` or `sharedconfigmaps` | `use` | Allows the Pod's SA to mount the shared resource |

--- a/pkg/csidriver/driver.go
+++ b/pkg/csidriver/driver.go
@@ -599,6 +599,10 @@ func mapBackingResourceToPod(dv *driverVolume) error {
 		// we can return the error back to volume provisioning, where the kubelet will retry at
 		// a controlled frequency
 		sharedSecret := client.GetSharedSecret(dv.GetSharedDataId())
+		if sharedSecret == nil {
+			klog.V(4).Infof("mapBackingResourceToPod for pod volume %s:%s:%s share %s no longer exists", dv.GetPodNamespace(), dv.GetPodName(), dv.GetVolID(), dv.GetSharedDataId())
+			return nil
+		}
 		sNamespace := sharedSecret.Spec.SecretRef.Namespace
 		sName := sharedSecret.Spec.SecretRef.Name
 		comboKey := objcache.BuildKey(sNamespace, sName)

--- a/pkg/csidriver/driver_test.go
+++ b/pkg/csidriver/driver_test.go
@@ -26,6 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -127,7 +130,7 @@ func TestCreateVolumeBadAccessType(t *testing.T) {
 	}
 }
 
-func TestMapBackingResourceHandlesForbiddenError(t *testing.T) {
+func TestMapBackingResourceHandlesPermissionDenied(t *testing.T) {
 	testCases := []struct {
 		name              string
 		shareObject       runtime.Object
@@ -220,12 +223,13 @@ func TestMapBackingResourceHandlesForbiddenError(t *testing.T) {
 			err = mapBackingResourceToPod(tc.driverVolume) // function under test
 
 			if err == nil {
-				t.Fatalf("mapBackingResourceToPod unexpectedly succeeded, but should have failed with a Forbidden error")
+				t.Fatalf("mapBackingResourceToPod unexpectedly succeeded, but should have failed with a PermissionDenied error")
 			}
-			if !kerrors.IsForbidden(err) {
-				t.Fatalf("Expected a Forbidden error, but got: %v", err)
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != codes.PermissionDenied {
+				t.Fatalf("Expected gRPC PermissionDenied error, but got: %v", err)
 			}
-			t.Logf("Successfully received expected Forbidden error: %v", err)
+			t.Logf("Successfully received expected PermissionDenied error: %v", err)
 		})
 	}
 }

--- a/pkg/csidriver/nodeserver_test.go
+++ b/pkg/csidriver/nodeserver_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -618,6 +619,25 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 	}
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cool-secret",
+			Namespace: "cool-secret-namespace",
+		},
+	}
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cool-configmap",
+			Namespace: "cool-configmap-namespace",
+		},
+	}
+	secretReactorFunc := func(action fakekubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &secret, nil
+	}
+	configMapReactorFunc := func(action fakekubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &configMap, nil
+	}
+
 	for ti := range tests {
 		test := &tests[ti]
 		t.Run(test.name, func(t *testing.T) {
@@ -630,6 +650,7 @@ func TestNodePublishVolume(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpDir)
 			defer os.RemoveAll(volPath)
+			defer ns.d.deleteVolume(test.nodePublishVolReq.VolumeId)
 
 			secretShareLister := &fakeSharedSecretLister{
 				sShare: test.secretShare,
@@ -643,6 +664,8 @@ func TestNodePublishVolume(t *testing.T) {
 			if test.reactor != nil {
 				sarClient := fakekubeclientset.NewSimpleClientset()
 				sarClient.PrependReactor("create", "subjectaccessreviews", test.reactor)
+				sarClient.PrependReactor("get", "secrets", secretReactorFunc)
+				sarClient.PrependReactor("get", "configmaps", configMapReactorFunc)
 				client.SetClient(sarClient)
 			}
 

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -153,7 +154,7 @@ func testServerForExpected(t *testing.T, testName string, port int, expected []m
 	if err != nil {
 		t.Fatalf("error requesting metrics server: %v in test %q", err, testName)
 	}
-	var p expfmt.TextParser
+	p := expfmt.NewTextParser(model.UTF8Validation)
 	mf, err := p.TextToMetricFamilies(resp.Body)
 	if err != nil {
 		t.Fatalf("error parsing server response: %v in test %q", err, testName)

--- a/test/e2e/rbac_test.go
+++ b/test/e2e/rbac_test.go
@@ -79,7 +79,7 @@ func verifyPodContent(t *testing.T, podName, namespace, expectedContent string) 
 
 func TestFixedHotReloadStaleData(t *testing.T) {
 	args := &framework.TestArgs{T: t}
-	framework.SetupClientsOutsideTestNamespace(args)
+	prep(args)
 	kubeClient = framework.KubeClient()
 	config, _ := client.GetConfig()
 	shareClient, err := sharev1clientset.NewForConfig(config)
@@ -371,4 +371,181 @@ func TestFixedHotReloadStaleData(t *testing.T) {
 	verifyPodContent(t, "pod-e", podNamespaces["pod-e"], "value3")
 
 	t.Logf("--- Test PASSED: UPDATE Successful on Driver RBAC Revoke ---")
+}
+
+func runRBACTest(t *testing.T, resourceType string, grantDriverRBAC, grantPodRBAC, expectPodUp bool) {
+	args := &framework.TestArgs{T: t}
+	prep(args)
+	kubeClient = framework.KubeClient()
+
+	config, err := client.GetConfig()
+	if err != nil {
+		t.Fatalf("failed to get config: %v", err)
+	}
+	shareClient, err := sharev1clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Error creating Shared Resource client: %v", err)
+	}
+
+	sourceNS := createTestNamespace(t, "e2e-source-ns-")
+	consumingNS := createTestNamespace(t, "e2e-consuming-ns-")
+	defer kubeClient.CoreV1().Namespaces().Delete(context.TODO(), sourceNS, metav1.DeleteOptions{})
+	defer kubeClient.CoreV1().Namespaces().Delete(context.TODO(), consumingNS, metav1.DeleteOptions{})
+
+	sourceName := "source-" + resourceType + "-" + framework.GenerateName("")
+	sharedName := "shared-" + resourceType + "-" + framework.GenerateName("")
+
+	// Create source resource - secret or configmap
+	if resourceType == "secret" {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: sourceName, Namespace: sourceNS},
+			StringData: map[string]string{"username": "admin"},
+		}
+		_, err = kubeClient.CoreV1().Secrets(sourceNS).Create(context.TODO(), secret, metav1.CreateOptions{})
+	} else {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: sourceName, Namespace: sourceNS},
+			Data:       map[string]string{"test-key": "test-value"},
+		}
+		_, err = kubeClient.CoreV1().ConfigMaps(sourceNS).Create(context.TODO(), cm, metav1.CreateOptions{})
+	}
+	if err != nil {
+		t.Fatalf("failed to create source %s: %v", resourceType, err)
+	}
+
+	// Create SharedSecret or SharedConfigMap
+	err = framework.CreateTestShare(args, sharedName, sourceName, sourceNS, resourceType)
+	if err != nil {
+		t.Fatalf("failed to create shared %s: %v", resourceType, err)
+	}
+	if resourceType == "secret" {
+		defer shareClient.SharedresourceV1alpha1().SharedSecrets().Delete(context.TODO(), sharedName, metav1.DeleteOptions{})
+	} else {
+		defer shareClient.SharedresourceV1alpha1().SharedConfigMaps().Delete(context.TODO(), sharedName, metav1.DeleteOptions{})
+	}
+
+	// Wait for share to be available
+	t.Logf("Waiting for shared %s %s to become available...", resourceType, sharedName)
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var getErr error
+		if resourceType == "secret" {
+			_, getErr = shareClient.SharedresourceV1alpha1().SharedSecrets().Get(ctx, sharedName, metav1.GetOptions{})
+		} else {
+			_, getErr = shareClient.SharedresourceV1alpha1().SharedConfigMaps().Get(ctx, sharedName, metav1.GetOptions{})
+		}
+		if kerrors.IsNotFound(getErr) {
+			return false, nil
+		}
+		return getErr == nil, getErr
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for shared %s %s: %v", resourceType, sharedName, err)
+	}
+
+	// RBAC resources differ by type
+	sharedResourceType := "sharedconfigmaps"
+	coreResourceType := "configmaps"
+	if resourceType == "secret" {
+		sharedResourceType = "sharedsecrets"
+		coreResourceType = "secrets"
+	}
+
+	// Create "use" ClusterRole
+	useClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "use-" + sharedName},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"sharedresource.openshift.io"},
+			Resources:     []string{sharedResourceType},
+			ResourceNames: []string{sharedName},
+			Verbs:         []string{"use"},
+		}},
+	}
+	_, err = kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), useClusterRole, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		t.Fatalf("failed to create 'use' cluster role: %v", err)
+	}
+	defer kubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), useClusterRole.Name, metav1.DeleteOptions{})
+
+	if grantDriverRBAC {
+		driverRole := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: "driver-access-" + sourceName, Namespace: sourceNS},
+			Rules: []rbacv1.PolicyRule{{
+				Verbs:         []string{"get", "list", "watch"},
+				APIGroups:     []string{""},
+				Resources:     []string{coreResourceType},
+				ResourceNames: []string{sourceName},
+			}},
+		}
+		_, err := kubeClient.RbacV1().Roles(sourceNS).Create(context.TODO(), driverRole, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create driver role: %v", err)
+		}
+		defer kubeClient.RbacV1().Roles(sourceNS).Delete(context.TODO(), driverRole.Name, metav1.DeleteOptions{})
+
+		driverRoleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "driver-binding-" + sourceName, Namespace: sourceNS},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "csi-driver-shared-resource", Namespace: "openshift-builds"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: driverRole.Name},
+		}
+		_, err = kubeClient.RbacV1().RoleBindings(sourceNS).Create(context.TODO(), driverRoleBinding, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create driver role binding: %v", err)
+		}
+		defer kubeClient.RbacV1().RoleBindings(sourceNS).Delete(context.TODO(), driverRoleBinding.Name, metav1.DeleteOptions{})
+	}
+
+	if grantPodRBAC {
+		podRoleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-use-" + sharedName, Namespace: consumingNS},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: useClusterRole.Name},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "default", Namespace: consumingNS}},
+		}
+		_, err = kubeClient.RbacV1().RoleBindings(consumingNS).Create(context.TODO(), podRoleBinding, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create pod role binding: %v", err)
+		}
+		defer kubeClient.RbacV1().RoleBindings(consumingNS).Delete(context.TODO(), podRoleBinding.Name, metav1.DeleteOptions{})
+	}
+
+	// Create and verify pod
+	args.Name = consumingNS
+	args.ShareNameOverride = sharedName
+	if resourceType == "secret" {
+		args.ShareType = "secret"
+	}
+	args.TestPodUp = expectPodUp
+	framework.CreateTestPod(args)
+
+	if expectPodUp {
+		args.TestDuration = 30 * time.Second
+		if resourceType == "secret" {
+			args.SearchString = "username"
+		} else {
+			args.SearchString = "test-key"
+		}
+		framework.ExecPod(args)
+	}
+}
+
+func TestSharedResourceRBAC(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		driverRBAC   bool
+		podRBAC      bool
+		expectPodUp  bool
+	}{
+		{"Secret_Success", "secret", true, true, true},
+		{"Secret_Failure_MissingDriverRBAC", "secret", false, true, false},
+		{"Secret_Failure_MissingPodRBAC", "secret", true, false, false},
+		{"ConfigMap_Success", "configmap", true, true, true},
+		{"ConfigMap_Failure_MissingDriverRBAC", "configmap", false, true, false},
+		{"ConfigMap_Failure_MissingPodRBAC", "configmap", true, false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runRBACTest(t, tc.resourceType, tc.driverRBAC, tc.podRBAC, tc.expectPodUp)
+		})
+	}
 }

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -43,6 +43,17 @@ func CreateTestPod(t *TestArgs) {
 	}
 	truVal := true
 	falVal := false
+
+	shareName := t.Name
+	if t.ShareNameOverride != "" {
+		shareName = t.ShareNameOverride
+	}
+
+	shareAttr := "sharedConfigMap"
+	if t.ShareType == "secret" {
+		shareAttr = "sharedSecret"
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.Name,
@@ -55,7 +66,7 @@ func CreateTestPod(t *TestArgs) {
 					VolumeSource: corev1.VolumeSource{
 						CSI: &corev1.CSIVolumeSource{
 							Driver:           string(operatorv1.SharedResourcesCSIDriver),
-							VolumeAttributes: map[string]string{"sharedConfigMap": t.Name},
+							VolumeAttributes: map[string]string{shareAttr: shareName},
 						},
 					},
 				},

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -16,6 +16,7 @@ type TestArgs struct {
 	Name                               string
 	Namespace                          string
 	ShareNameOverride                  string
+	ShareType                          string // secret or configmap (default -> configmap)
 	SecondName                         string
 	ChangeName                         string
 	SearchString                       string


### PR DESCRIPTION
This PR adds a tests which ensure mount fails when csi-driver or pod lacks required permissions to access SharedSecrets/ConfigMaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive RBAC configuration guide covering driver-level and pod-level permissions required for mounting shared secrets and config maps, including troubleshooting scenarios.

* **Bug Fixes**
  * Fixed potential nil reference when a shared secret is no longer available.

* **Tests**
  * Added end-to-end RBAC tests validating permission scenarios for shared secrets and config maps.
  * Enhanced test framework with improved setup and shared resource helpers.

* **Chores**
  * Updated build environment to Go 1.25 and OpenShift 4.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->