### PR TITLE
BUILD-1545: Fix error-handling for shared resources RBAC

### DIFF
--- a/pkg/cache/secrets.go
+++ b/pkg/cache/secrets.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/openshift/csi-driver-shared-resource/pkg/client"
 	"github.com/openshift/csi-driver-shared-resource/pkg/config"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/codes"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 /*
@@ -65,18 +68,28 @@ func DelSecret(secret *corev1.Secret) {
 // RegisterSecretUpsertCallback will be called as part of the kubelet sending a mount CSI volume request for a pod;
 // if the corresponding share references a secret, then the function registered here will be called to possibly change
 // storage
-func RegisterSecretUpsertCallback(volID, sID string, f func(key, value interface{}) bool) {
+func RegisterSecretUpsertCallback(volID, sID string, f func(key, value interface{}) bool) error {
 	if !config.LoadedConfig.RefreshResources {
-		return
+		return nil
 	}
 	secretUpsertCallbacks.Store(volID, f)
 	ns, name, _ := SplitKey(sID)
-	s := client.GetSecret(ns, name)
+	s, err := client.GetSecret(ns, name)
+	if err != nil {
+		klog.Warningf("could not get secret for %s vol %s", sID, volID)
+
+		if kerrors.IsForbidden(err) {
+			return status.Errorf(codes.PermissionDenied, "csi driver is forbidden to access secret %s/%s: %v", ns, name, err)
+		}
+		return status.Errorf(codes.Internal, "csi driver failed to get secret %s/%s: %v", ns, name, err)
+	}
+
 	if s != nil {
 		f(BuildKey(s.Namespace, s.Name), s)
 	} else {
-		klog.Warningf("not found on secret with key %s vol %s", sID, volID)
+		klog.Warningf("not found on get secret with key %s vol %s", sID, volID)
 	}
+	return nil
 }
 
 // UnregisterSecretUpsertCallback will be called as part of the kubelet sending a delete CSI volume request for a pod

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"sync"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +48,7 @@ func GetListers() *Listers {
 	return &singleton
 }
 
-func GetSecret(namespace, name string) *corev1.Secret {
+func GetSecret(namespace, name string) (*corev1.Secret, error) {
 	var lister corelistersv1.SecretLister
 	obj, ok := singleton.Secrets.Load(namespace)
 	if ok {
@@ -56,21 +57,23 @@ func GetSecret(namespace, name string) *corev1.Secret {
 	if lister != nil {
 		s, err := lister.Secrets(namespace).Get(name)
 		if err == nil {
-			return s
+			return s, nil
 		}
 		klog.V(4).Infof("GetSecret lister for %s/%s got error: %s", namespace, name, err.Error())
 	}
 	if kubeClient != nil {
 		s, err := kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if err == nil {
-			return s
+		if err != nil {
+			// "forbidden" error will be caught and returned
+			klog.V(4).Infof("GetSecret client for %s/%s got error: %s", namespace, name, err.Error())
+			return nil, err
 		}
-		klog.V(4).Infof("GetSecret client for %s/%s got error: %s", namespace, name, err.Error())
+		return s, nil
 	}
-	return nil
+	return nil, fmt.Errorf("no secret lister or kubeClient available for namespace %s", namespace)
 }
 
-func GetConfigMap(namespace, name string) *corev1.ConfigMap {
+func GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
 	var lister corelistersv1.ConfigMapLister
 	obj, ok := singleton.ConfigMaps.Load(namespace)
 	if ok {
@@ -79,18 +82,20 @@ func GetConfigMap(namespace, name string) *corev1.ConfigMap {
 	if lister != nil {
 		cm, err := lister.ConfigMaps(namespace).Get(name)
 		if err == nil {
-			return cm
+			return cm, nil
 		}
 		klog.V(4).Infof("GetConfigMap lister for %s/%s got error: %s", namespace, name, err.Error())
 	}
 	if kubeClient != nil {
 		cm, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if err == nil {
-			return cm
+		if err != nil {
+			// "forbidden" error will be caught and returned
+			klog.V(4).Infof("GetConfigMap client for %s/%s got error: %s", namespace, name, err.Error())
+			return nil, err
 		}
-		klog.V(4).Infof("GetConfigMap client for %s/%s got error: %s", namespace, name, err.Error())
+		return cm, nil
 	}
-	return nil
+	return nil, fmt.Errorf("no configmap lister or kubeClient available for namespace %s", namespace)
 }
 
 func GetSharedSecret(name string) *sharev1alpha1.SharedSecret {

--- a/pkg/csidriver/driver.go
+++ b/pkg/csidriver/driver.go
@@ -42,6 +42,9 @@ import (
 	"github.com/openshift/csi-driver-shared-resource/pkg/client"
 	"github.com/openshift/csi-driver-shared-resource/pkg/config"
 	"github.com/openshift/csi-driver-shared-resource/pkg/consts"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type driver struct {
@@ -378,7 +381,7 @@ func (r *innerShareDeleteRanger) Range(key, value interface{}) bool {
 			// we just delete the associated data from the previously provisioned volume;
 			// we don't delete the volume in case the share is added back
 		}
-		return false
+		return true
 	}
 	return true
 }
@@ -432,7 +435,7 @@ func (r *innerShareUpdateRanger) Range(key, value interface{}) bool {
 			klog.V(0).Infof("innerShareUpdateRanger pod %s:%s has permissions for secretShare %s",
 				dv.GetPodNamespace(), dv.GetPodName(), r.shareId)
 		} else {
-			klog.V(0).Infof("innerShareUpdateRanger pod %s:%s does not permission for secretShare %s",
+			klog.V(0).Infof("innerShareUpdateRanger pod %s:%s does not have permission for secretShare %s",
 				dv.GetPodNamespace(), dv.GetPodName(), r.shareId)
 		}
 
@@ -441,13 +444,13 @@ func (r *innerShareUpdateRanger) Range(key, value interface{}) bool {
 			sharedSecret := client.GetSharedSecret(r.shareId)
 			if sharedSecret == nil {
 				klog.Warningf("innerShareUpdateRanger unexpected not found on sharedSecret lister refresh: %s", r.shareId)
-				return false
+				return true
 			}
 			r.sharedItemKey = objcache.BuildKey(sharedSecret.Spec.SecretRef.Namespace, sharedSecret.Spec.SecretRef.Name)
-			secretObj := client.GetSecret(sharedSecret.Spec.SecretRef.Namespace, sharedSecret.Spec.SecretRef.Name)
-			if secretObj == nil {
-				klog.Infof("innerShareUpdateRanger share %s could not retrieve shared item %s", r.shareId, r.sharedItemKey)
-				return false
+			secretObj, err := client.GetSecret(sharedSecret.Spec.SecretRef.Namespace, sharedSecret.Spec.SecretRef.Name)
+			if err != nil || secretObj == nil {
+				klog.Warningf("innerShareUpdateRanger share %s could not retrieve shared item %s, error: %v", r.shareId, r.sharedItemKey, err)
+				return true
 			}
 			r.sharedItem = Payload{
 				ByteData:   secretObj.Data,
@@ -457,13 +460,13 @@ func (r *innerShareUpdateRanger) Range(key, value interface{}) bool {
 			sharedConfigMap := client.GetSharedConfigMap(r.shareId)
 			if sharedConfigMap == nil {
 				klog.Warningf("innerShareUpdateRanger unexpected not found on sharedConfigMap lister refresh: %s", r.shareId)
-				return false
+				return true
 			}
 			r.sharedItemKey = objcache.BuildKey(sharedConfigMap.Spec.ConfigMapRef.Namespace, sharedConfigMap.Spec.ConfigMapRef.Name)
-			cmObj := client.GetConfigMap(sharedConfigMap.Spec.ConfigMapRef.Namespace, sharedConfigMap.Spec.ConfigMapRef.Name)
-			if cmObj == nil {
-				klog.Infof("innerShareUpdateRanger share %s could not retrieve shared item %s", r.shareId, r.sharedItemKey)
-				return false
+			cmObj, err := client.GetConfigMap(sharedConfigMap.Spec.ConfigMapRef.Namespace, sharedConfigMap.Spec.ConfigMapRef.Name)
+			if err != nil || cmObj == nil {
+				klog.Warningf("innerShareUpdateRanger share %s could not retrieve shared item %s, error: %v", r.shareId, r.sharedItemKey, err)
+				return true
 			}
 			r.sharedItem = Payload{
 				StringData: cmObj.Data,
@@ -484,7 +487,7 @@ func (r *innerShareUpdateRanger) Range(key, value interface{}) bool {
 			objcache.UnregisterSecretDeleteCallback(r.volID)
 			objcache.UnregisterConfigMapDeleteCallback(r.volID)
 			objcache.UnregisterConfigMapUpsertCallback(r.volID)
-			return false
+			return true // Continue the loop for other volumes
 		}
 
 		commonUpsertRanger(dv, r.sharedItemKey, r.sharedItem)
@@ -547,7 +550,14 @@ func mapBackingResourceToPod(dv *driverVolume) error {
 		cmNamespace := sharedConfigMap.Spec.ConfigMapRef.Namespace
 		cmName := sharedConfigMap.Spec.ConfigMapRef.Name
 		comboKey := objcache.BuildKey(cmNamespace, cmName)
-		cm := client.GetConfigMap(cmNamespace, cmName)
+		cm, err := client.GetConfigMap(cmNamespace, cmName)
+		if err != nil {
+			if kerrors.IsForbidden(err) {
+				return status.Errorf(codes.PermissionDenied, "CSI driver is forbidden to access configmap %s/%s: %v", cmNamespace, cmName, err)
+			}
+			// Translate any other error to gRPC Internal
+			return status.Errorf(codes.Internal, "CSI driver failed to get configmap %s/%s: %v", cmNamespace, cmName, err)
+		}
 		if cm != nil {
 			payload := Payload{
 				StringData: cm.Data,
@@ -592,7 +602,15 @@ func mapBackingResourceToPod(dv *driverVolume) error {
 		sNamespace := sharedSecret.Spec.SecretRef.Namespace
 		sName := sharedSecret.Spec.SecretRef.Name
 		comboKey := objcache.BuildKey(sNamespace, sName)
-		s := client.GetSecret(sNamespace, sName)
+		s, err := client.GetSecret(sNamespace, sName)
+		if err != nil {
+			if kerrors.IsForbidden(err) {
+				// Translate Forbidden to gRPC PermissionDenied
+				return status.Errorf(codes.PermissionDenied, "CSI driver is forbidden to access secret %s/%s: %v", sNamespace, sName, err)
+			}
+			// Translate any other error to gRPC Internal
+			return status.Errorf(codes.Internal, "CSI driver failed to get secret %s/%s: %v", sNamespace, sName, err)
+		}
 		if s != nil {
 			payload := Payload{
 				ByteData: s.Data,

--- a/pkg/csidriver/driver_test.go
+++ b/pkg/csidriver/driver_test.go
@@ -29,6 +29,7 @@ import (
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -124,6 +125,109 @@ func TestCreateVolumeBadAccessType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported access type") {
 		t.Fatalf("unexpected err %s", err.Error())
+	}
+}
+
+func TestMapBackingResourceHandlesForbiddenError(t *testing.T) {
+	testCases := []struct {
+		name              string
+		shareObject       runtime.Object
+		driverVolume      *driverVolume
+		reactorResource   string
+		resourceName      string
+		resourceNamespace string
+	}{
+		{
+			name: "forbidden Secret",
+			shareObject: &sharev1alpha1.SharedSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-secret-share"},
+				Spec: sharev1alpha1.SharedSecretSpec{
+					SecretRef: sharev1alpha1.SharedSecretReference{
+						Name:      "my-forbidden-secret",
+						Namespace: "my-namespace",
+					},
+				},
+			},
+			driverVolume: &driverVolume{
+				VolID:          "test-volume-secret",
+				SharedDataId:   "test-secret-share",
+				SharedDataKind: "Secret",
+				Lock:           &sync.Mutex{},
+			},
+			reactorResource:   "secrets",
+			resourceName:      "my-forbidden-secret",
+			resourceNamespace: "my-namespace",
+		},
+		{
+			name: "forbidden ConfigMap",
+			shareObject: &sharev1alpha1.SharedConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cm-share"},
+				Spec: sharev1alpha1.SharedConfigMapSpec{
+					ConfigMapRef: sharev1alpha1.SharedConfigMapReference{
+						Name:      "my-forbidden-cm",
+						Namespace: "my-namespace",
+					},
+				},
+			},
+			driverVolume: &driverVolume{
+				VolID:          "test-volume-cm",
+				SharedDataId:   "test-cm-share",
+				SharedDataKind: "ConfigMap",
+				Lock:           &sync.Mutex{},
+			},
+			reactorResource:   "configmaps",
+			resourceName:      "my-forbidden-cm",
+			resourceNamespace: "my-namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := fakekubeclientset.NewSimpleClientset()
+			shareClient := fakeshareclientset.NewSimpleClientset()
+			client.SetClient(k8sClient)
+			client.SetShareClient(shareClient)
+
+			forbiddenReactorFunc := func(action fakekubetesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, kerrors.NewForbidden(corev1.Resource(tc.reactorResource), tc.resourceName, fmt.Errorf("access denied by test"))
+			}
+			k8sClient.PrependReactor("get", tc.reactorResource, forbiddenReactorFunc)
+
+			testName := strings.ReplaceAll(t.Name(), "/", "_")
+
+			targetPath, err := os.MkdirTemp(os.TempDir(), testName)
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(targetPath)
+			tc.driverVolume.TargetPath = targetPath
+
+			// Pre-load the share object into the cache and set up a reactor for it
+			switch share := tc.shareObject.(type) {
+			case *sharev1alpha1.SharedSecret:
+				cache.AddSharedSecret(share)
+				shareReactorFunc := func(action fakekubetesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, share, nil
+				}
+				shareClient.PrependReactor("get", "sharedsecrets", shareReactorFunc)
+			case *sharev1alpha1.SharedConfigMap:
+				cache.AddSharedConfigMap(share)
+				shareReactorFunc := func(action fakekubetesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, share, nil
+				}
+				shareClient.PrependReactor("get", "sharedconfigmaps", shareReactorFunc)
+			}
+
+			err = mapBackingResourceToPod(tc.driverVolume) // function under test
+
+			if err == nil {
+				t.Fatalf("mapBackingResourceToPod unexpectedly succeeded, but should have failed with a Forbidden error")
+			}
+			if !kerrors.IsForbidden(err) {
+				t.Fatalf("Expected a Forbidden error, but got: %v", err)
+			}
+			t.Logf("Successfully received expected Forbidden error: %v", err)
+		})
 	}
 }
 

--- a/test/e2e/rbac_test.go
+++ b/test/e2e/rbac_test.go
@@ -1,0 +1,372 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	sharev1alpha1 "github.com/openshift/api/sharedresource/v1alpha1"
+	sharev1clientset "github.com/openshift/client-go/sharedresource/clientset/versioned"
+	"github.com/openshift/csi-driver-shared-resource/pkg/client"
+	"github.com/openshift/csi-driver-shared-resource/test/framework"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	kubeClient kubernetes.Interface
+)
+
+func createTestNamespace(t *testing.T, baseName string) string {
+	namespaceName := framework.GenerateName(baseName)
+	t.Logf("Creating test namespace %s", namespaceName)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		t.Fatalf("failed to create test namespace %s: %v", namespaceName, err)
+	}
+	return namespaceName
+}
+
+// Fetches the logs of a specific container within a given pod.
+func getPodLogs(podName, namespace, containerName string) (string, error) {
+	podLogOpts := corev1.PodLogOptions{
+		Container: containerName,
+	}
+	req := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
+	podLogs, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", fmt.Errorf("error in opening stream for container %s: %v", containerName, err)
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", fmt.Errorf("error in copying info from podLogs to buf: %v", err)
+	}
+	return buf.String(), nil
+}
+
+// Polls the logs of a pod until it sees the expected content.
+func verifyPodContent(t *testing.T, podName, namespace, expectedContent string) {
+	err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		logs, err := getPodLogs(podName, namespace, "my-frontend")
+		if err != nil {
+			t.Logf("Warning: could not get logs for pod %s: %v", podName, err)
+			return false, nil // Continue polling
+		}
+		if strings.Contains(logs, expectedContent) {
+			t.Logf("Pod '%s' contains '%s'", podName, expectedContent)
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to verify content for pod '%s': timed out waiting for '%s': %v", podName, expectedContent, err)
+	}
+}
+
+func TestFixedHotReloadStaleData(t *testing.T) {
+	args := &framework.TestArgs{T: t}
+	framework.SetupClientsOutsideTestNamespace(args)
+	kubeClient = framework.KubeClient()
+	config, _ := client.GetConfig()
+	shareClient, err := sharev1clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Error creating Shared Resource client: %v", err)
+	}
+
+	// SETUP
+	t.Log("Setting up resources for the test.")
+	sourceNamespace := createTestNamespace(t, "e2e-source-")
+	defer kubeClient.CoreV1().Namespaces().Delete(context.TODO(), sourceNamespace, metav1.DeleteOptions{})
+
+	secretV1 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-v1", Namespace: sourceNamespace},
+		StringData: map[string]string{"key": "value1"},
+	}
+	secretV2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-v2", Namespace: sourceNamespace},
+		StringData: map[string]string{"key": "value2"},
+	}
+	secretV3 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-v3", Namespace: sourceNamespace},
+		StringData: map[string]string{"key": "value3"},
+	}
+	_, err = kubeClient.CoreV1().Secrets(sourceNamespace).Create(context.TODO(), secretV1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create secret-v1: %v", err)
+	}
+	_, err = kubeClient.CoreV1().Secrets(sourceNamespace).Create(context.TODO(), secretV2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create secret-v2: %v", err)
+	}
+	_, err = kubeClient.CoreV1().Secrets(sourceNamespace).Create(context.TODO(), secretV3, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create secret-v3: %v", err)
+	}
+
+	sharedSecret := &sharev1alpha1.SharedSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "data-share"},
+		Spec: sharev1alpha1.SharedSecretSpec{
+			SecretRef: sharev1alpha1.SharedSecretReference{Name: "secret-v1", Namespace: sourceNamespace},
+		},
+	}
+	_, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Create(context.TODO(), sharedSecret, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create SharedSecret: %v", err)
+	}
+	defer shareClient.SharedresourceV1alpha1().SharedSecrets().Delete(context.TODO(), sharedSecret.Name, metav1.DeleteOptions{})
+
+	// PERMISSIONS
+	driverRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "driver-access", Namespace: sourceNamespace},
+		Rules: []rbacv1.PolicyRule{{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+		}},
+	}
+	_, err = kubeClient.RbacV1().Roles(sourceNamespace).Create(context.TODO(), driverRole, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create driver role: %v", err)
+	}
+	defer kubeClient.RbacV1().Roles(sourceNamespace).Delete(context.TODO(), driverRole.Name, metav1.DeleteOptions{})
+
+	driverRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "driver-binding", Namespace: sourceNamespace},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "csi-driver-shared-resource", Namespace: "openshift-builds"}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: driverRole.Name},
+	}
+	_, err = kubeClient.RbacV1().RoleBindings(sourceNamespace).Create(context.TODO(), driverRoleBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create driver role binding: %v", err)
+	}
+	defer kubeClient.RbacV1().RoleBindings(sourceNamespace).Delete(context.TODO(), driverRoleBinding.Name, metav1.DeleteOptions{})
+
+	useClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "use-" + sharedSecret.Name},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"sharedresource.openshift.io"},
+			Resources:     []string{"sharedsecrets"},
+			ResourceNames: []string{sharedSecret.Name},
+			Verbs:         []string{"use"},
+		}},
+	}
+	_, err = kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), useClusterRole, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		t.Fatalf("Failed to create 'use' cluster role: %v", err)
+	}
+	defer kubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), useClusterRole.Name, metav1.DeleteOptions{})
+
+	podNamespaces := make(map[string]string)
+	podNames := []string{"pod-a", "pod-b", "pod-c", "pod-d", "pod-e"}
+	for _, podName := range podNames {
+		ns := createTestNamespace(t, fmt.Sprintf("e2e-%s-", podName))
+		podNamespaces[podName] = ns
+		defer kubeClient.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+	}
+
+	readOnly := true
+	for _, podName := range podNames {
+		consumingNS := podNamespaces[podName]
+		podRoleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-use-share", Namespace: consumingNS},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: useClusterRole.Name},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "default", Namespace: consumingNS}},
+		}
+		_, err = kubeClient.RbacV1().RoleBindings(consumingNS).Create(context.TODO(), podRoleBinding, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create pod role binding: %v", err)
+		}
+		defer kubeClient.RbacV1().RoleBindings(consumingNS).Delete(context.TODO(), podRoleBinding.Name, metav1.DeleteOptions{})
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: consumingNS},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:    "my-frontend",
+					Image:   "registry.access.redhat.com/ubi8/ubi-minimal",
+					Command: []string{"/bin/sh", "-c", "while true; do if [ -f /data/key ]; then echo -n ''; cat /data/key; echo; fi; sleep 2; done"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name: "my-csi-volume", MountPath: "/data", ReadOnly: true,
+					}},
+				}},
+				Volumes: []corev1.Volume{{
+					Name: "my-csi-volume",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           "csi.sharedresource.openshift.io",
+							ReadOnly:         &readOnly,
+							VolumeAttributes: map[string]string{"sharedSecret": sharedSecret.Name},
+						},
+					},
+				}},
+				ServiceAccountName: "default",
+			},
+		}
+		podClient := kubeClient.CoreV1().Pods(consumingNS)
+		_, err = podClient.Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create pod %s: %v", podName, err)
+		}
+		err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			p, err := podClient.Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			return p.Status.Phase == corev1.PodRunning, nil
+		})
+		if err != nil {
+			t.Fatalf("Pod %s did not reach running state: %v", podName, err)
+		}
+	}
+
+	for _, podName := range podNames {
+		verifyPodContent(t, podName, podNamespaces[podName], "value1")
+	}
+
+	// UPDATE SCENARIO
+	t.Log("Updating all pods to use secret-v2")
+	sharedSecret, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Get(context.TODO(), sharedSecret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get latest SharedSecret before update: %v", err)
+	}
+	sharedSecret.Spec.SecretRef.Name = "secret-v2"
+	_, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Update(context.TODO(), sharedSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update SharedSecret to point to v2: %v", err)
+	}
+
+	for _, podName := range podNames {
+		verifyPodContent(t, podName, podNamespaces[podName], "value2")
+	}
+
+	// POD RBAC REVOKE SCENARIO
+	t.Log("--- Starting Test Case: Pod RBAC Revoke ---")
+
+	t.Logf("[DO] Revoking 'use' permission for pod-c by deleting its RoleBinding.")
+	if err := kubeClient.RbacV1().RoleBindings(podNamespaces["pod-c"]).Delete(context.TODO(), "pod-use-share", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("failed to delete pod-c rolebinding to simulate RBAC revoke: %v", err)
+	}
+	t.Logf("[DONE] Deleted RoleBinding for pod-c.")
+
+	t.Logf("[DO] Triggering update by pointing SharedSecret to secret-v3")
+	sharedSecret, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Get(context.TODO(), sharedSecret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get latest SharedSecret before v3 update: %v", err)
+	}
+	sharedSecret.Spec.SecretRef.Name = "secret-v3"
+	_, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Update(context.TODO(), sharedSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update SharedSecret to v3: %v", err)
+	}
+	t.Logf("[DONE] Updated SharedSecret to point to secret-v3.")
+
+	time.Sleep(15 * time.Second)
+
+	verifyPodContent(t, "pod-a", podNamespaces["pod-a"], "value3")
+	verifyPodContent(t, "pod-b", podNamespaces["pod-b"], "value3")
+	verifyPodContent(t, "pod-d", podNamespaces["pod-d"], "value3")
+	verifyPodContent(t, "pod-e", podNamespaces["pod-e"], "value3")
+
+	t.Logf("Verifying pod-c was NOT updated to value3 and retained value2.")
+	if logs, err := getPodLogs("pod-c", podNamespaces["pod-c"], "my-frontend"); err == nil {
+		if strings.Contains(logs, "value3") {
+			t.Fatalf("FAILED: pod-c should not have updated to value3, but it did.")
+		}
+		if !strings.Contains(logs, "value2") {
+			t.Fatalf("FAILED: pod-c should have retained value2, but it did not.")
+		}
+		t.Logf("Success: Pod-c did not update to value3 and retained 'value2'.")
+	} else {
+		t.Logf("Warning: could not retrieve logs for pod-c to verify non-update: %v", err)
+	}
+	t.Logf("--- Test PASSED: UPDATE Successful on Pod RBAC Revoke ---")
+
+	// FAILURE SCENARIO
+	t.Logf("--- Starting Test Case: Check if update succeeds on deleting secret-v2 ---")
+
+	t.Logf("[DO] Introducing a failure by deleting a source secret (secret-v2)")
+	err = kubeClient.CoreV1().Secrets(sourceNamespace).Delete(context.TODO(), "secret-v2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete secret-v2 to introduce failure: %v", err)
+	}
+	t.Logf("[DONE] Deleted secret-v2.")
+
+	t.Logf("[DO] Update SharedSecret back to the deleted secret to force refresh")
+	sharedSecret, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Get(context.TODO(), sharedSecret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get latest SharedSecret before update: %v", err)
+	}
+	sharedSecret.Spec.SecretRef.Name = "secret-v2"
+	_, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Update(context.TODO(), sharedSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update SharedSecret to trigger reload: %v", err)
+	}
+	t.Logf("[DONE] Updated SharedSecret to point to deleted secret-v2.")
+
+	t.Log("Verifying that all pods have retained their last known good data")
+	time.Sleep(20 * time.Second)
+
+	verifyPodContent(t, "pod-a", podNamespaces["pod-a"], "value3")
+	verifyPodContent(t, "pod-b", podNamespaces["pod-b"], "value3")
+	verifyPodContent(t, "pod-c", podNamespaces["pod-c"], "value2") // Didn't get value3
+	verifyPodContent(t, "pod-d", podNamespaces["pod-d"], "value3")
+	verifyPodContent(t, "pod-e", podNamespaces["pod-e"], "value3")
+
+	t.Logf("--- Test PASSED: UPDATE Successful on Deleting Secret ---")
+
+	// DRIVER RBAC REMOVE SCENARIO
+	t.Logf("--- Starting Test Case: Driver RBAC Revoke ---")
+
+	sharedSecret, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Get(context.TODO(), sharedSecret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get latest SharedSecret before state restore: %v", err)
+	}
+	sharedSecret.Spec.SecretRef.Name = "secret-v3"
+	_, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Update(context.TODO(), sharedSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update SharedSecret to restored v3: %v", err)
+	}
+	time.Sleep(15 * time.Second)
+
+	t.Logf("[DO] Revoking driver's 'get' permission for secrets")
+	err = kubeClient.RbacV1().RoleBindings(sourceNamespace).Delete(context.TODO(), driverRoleBinding.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete driver role binding to simulate RBAC revoke: %v", err)
+	}
+	t.Logf("[DONE] Deleted driver RoleBinding.")
+
+	t.Logf("[DO] Triggering update by pointing SharedSecret to secret-v1")
+	sharedSecret, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Get(context.TODO(), sharedSecret.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get latest SharedSecret before v1 update: %v", err)
+	}
+	sharedSecret.Spec.SecretRef.Name = "secret-v1"
+	_, err = shareClient.SharedresourceV1alpha1().SharedSecrets().Update(context.TODO(), sharedSecret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update SharedSecret to v1: %v", err)
+	}
+	t.Logf("[DONE] Updated SharedSecret to point to secret-v1.")
+
+	t.Log("Verifying that all pods have retained their last known data due to driver permission failure")
+	time.Sleep(20 * time.Second)
+
+	verifyPodContent(t, "pod-a", podNamespaces["pod-a"], "value3")
+	verifyPodContent(t, "pod-b", podNamespaces["pod-b"], "value3")
+	verifyPodContent(t, "pod-c", podNamespaces["pod-c"], "value2")
+	verifyPodContent(t, "pod-d", podNamespaces["pod-d"], "value3")
+	verifyPodContent(t, "pod-e", podNamespaces["pod-e"], "value3")
+
+	t.Logf("--- Test PASSED: UPDATE Successful on Driver RBAC Revoke ---")
+}

--- a/test/framework/client.go
+++ b/test/framework/client.go
@@ -66,3 +66,8 @@ func setRESTConfigDefaults(config rest.Config) *rest.Config {
 	config.APIPath = "/api"
 	return &config
 }
+
+// Returns framework's kubernetes clientset.
+func KubeClient() *kubeset.Clientset {
+	return kubeClient
+}

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -17,7 +17,7 @@ const (
 	maxGeneratedNameLength = maxNameLength - randomLength
 )
 
-func generateName(base string) string {
+func GenerateName(base string) string {
 	if len(base) > maxGeneratedNameLength {
 		base = base[:maxGeneratedNameLength]
 	}
@@ -26,7 +26,7 @@ func generateName(base string) string {
 }
 
 func CreateTestNamespace(t *TestArgs) string {
-	testNamespace := generateName("e2e-test-csi-driver-shared-resource-")
+	testNamespace := GenerateName("e2e-test-csi-driver-shared-resource-")
 	t.T.Logf("%s: Creating test namespace %s", time.Now().String(), testNamespace)
 	ns := &corev1.Namespace{}
 	ns.Name = testNamespace

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -14,6 +14,7 @@ var (
 type TestArgs struct {
 	T                                  *testing.T
 	Name                               string
+	Namespace                          string
 	ShareNameOverride                  string
 	SecondName                         string
 	ChangeName                         string


### PR DESCRIPTION
Files changed:

### 1. pkg/client/listers.go

- Functions Changed: `GetSecret`, `GetConfigMap`
- What Was Changed: The function signatures were modified to return an `error` object. The implementation was updated to capture and return any error received from the Kubernetes API client, instead of just logging it and returning `nil`.
    
- Why: This is the primary bug fix. The previous implementation ignored `Forbidden` errors, making it impossible for the driver to distinguish between a resource that was "not found" vs one it was denied access to. By propagating the error, this change enables the driver logic to correctly identify and act on the permission failures.

### 2. pkg/csidriver/driver.go

- Functions Changed: `mapBackingResourceToPod`, `innerShareUpdateRanger`
- What Was Changed:
    - In `mapBackingResourceToPod`, the logic was updated to handle the new `error` return from `GetSecret`/`GetConfigMap`. It now specifically checks if the error `IsForbidden` and, if so, returns the error to the caller. This fails the initial volume mount. A `nil` check was also added to prevent the driver from crashing if a non-forbidden error occurs.
    - In `innerShareUpdateRanger`, the logic was updated to handle the new `error` return. Additionally, in 2 places (when a resource fetch fails and when a pod's permissions are revoked), the function's return value was changed from `false` to `true`.
        
- Why:
    - The changes to `mapBackingResourceToPod` consume the bug fix. This is the logic that enforces the RBAC check during a pod's startup, preventing the security vulnerability.
    - Changing the return value to `true` ensures that if one volume update fails, the loop continues for all other volumes. This prevents a single failure from causing data inconsistency, which could lead to security risks.


### 3. pkg/cache/secrets.go and 4. pkg/cache/configmaps.go

- Functions Changed: `RegisterSecretUpsertCallback`, `RegisterConfigMapUpsertCallback`
- What Was Changed: The calls to `client.GetSecret` and `client.GetConfigMap` were updated to correctly handle the new return signature. The code now checks that the returned `error` is `nil` before proceeding to use the resource object.
    
- Why: As these functions were calling functions in `listers.go` (which were modified), these had to be updated.
    
### 5. pkg/cache/shares.go

- Functions Changed: `AddSharedConfigMap`, `AddSharedSecret`
- What Was Changed: The calls to client.GetConfigMap and client.GetSecret were updated to correctly handle the new return signature. The code now captures and logs any error that occurs when fetching the backing resource during a share creation event.

- Why: As these functions were calling functions in `listers.go` (which were modified), these had to be updated.

### 6. pkg/csidriver/driver_test.go

- Functions Changed: A new function, `TestMapBackingResourceHandlesForbiddenError`, was added.
- What Was Changed: A new table-driven unit test was added to provide specific coverage for the bug fix. This test uses a fake Kubernetes client and a reactor to simulate the API server returning a `Forbidden` error.
    
- Why: This test proves that the fix works for both Secrets and ConfigMaps. It asserts that when the driver encounters a `Forbidden` error, it correctly propagates that error instead of ignoring it. 