### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-shared-resource-webhook-1-4

### DIFF
--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -19,11 +19,12 @@ ENTRYPOINT ["./openshift-builds-shared-resource-webhook"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource-webhook" \
-	name="openshift-builds/csi-driver-shared-resource-webhook" \
+	name="openshift-builds/openshift-builds-shared-resource-webhook-rhel9" \
 	version="v1.4.0" \
 	summary="Red Hat OpenShift Builds Shared Resource Webhook" \
 	maintainer="openshift-builds@redhat.com" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
 	io.k8s.display-name="Red Hat OpenShift Builds Shared Resource Webhook" \
-	io.openshift.tags="builds,shared-resources,webhook,csi-driver"
+	io.openshift.tags="builds,shared-resources,webhook,csi-driver" \
+	cpe="cpe:/a:redhat:openshift_builds:1.4::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
