### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openshift-builds-shared-resource-1-2

### DIFF
--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -15,11 +15,12 @@ ENTRYPOINT ["./openshift-builds-shared-resource"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource" \
-	name="openshift-builds/csi-driver-shared-resource" \
+	name="openshift-builds/openshift-builds-shared-resource-rhel9" \
 	version="v1.1.0" \
 	summary="Red Hat OpenShift Builds Shared Resource" \
 	maintainer="openshift-builds@redhat.com" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
 	io.k8s.display-name="Red Hat OpenShift Builds Shared Resource" \
-	io.openshift.tags="builds,shared-resources,csi-driver"
+	io.openshift.tags="builds,shared-resources,csi-driver" \
+	cpe="cpe:/a:redhat:openshift_builds:1.2::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
