### PR TITLE
[builds-1.7] Update go-toolset base image SHA

### DIFF
--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:8b211cc8793d8013140844e8070aa584a8eb3e4e6e842ea4b03dd9914b1a5dc6 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:8b211cc8793d8013140844e8070aa584a8eb3e4e6e842ea4b03dd9914b1a5dc6 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 


### PR DESCRIPTION
## Summary
- Updates `go-toolset` digest in `.konflux/shared-resource/Dockerfile` and `.konflux/shared-resource-webhook/Dockerfile`
- `sha256:8b211cc8793d...` → `sha256:d637b9dfccb1...`

Co-Authored-By: Claude Opus 4.6 <noreply>