### PR TITLE
[BUILD-2055] Release prep for builds-1.8

### DIFF
--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:180d433d97773ac90384662ee0f54c3b474f6eeb7219e414a4ca323d1196bb13 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o /tmp/openshift-builds-shared-resource-webhook ./cmd/webhook
 
-FROM registry.redhat.io/ubi9-minimal@sha256:f225a0f8eb7d258011e1f7c8b025dc7dd155d6ffc66c17cd203dcec88935b455
+FROM registry.redhat.io/ubi9-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23
 
 WORKDIR /
 
@@ -19,7 +19,7 @@ ENTRYPOINT ["./openshift-builds-shared-resource-webhook"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource-webhook" \
-	cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+	cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
 	distribution-scope="public" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
@@ -31,4 +31,4 @@ LABEL \
 	summary="Red Hat OpenShift Builds Shared Resource Webhook" \
 	url="https://github.com/openshift/csi-driver-shared-resource" \
 	vendor="Red Hat, Inc." \
-	version="v1.7.0"
+	version="v1.8.0"

--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o /tmp/openshift-builds-shared-resource-webhook ./cmd/webhook
 
-FROM registry.redhat.io/ubi9-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23
+FROM registry.redhat.io/ubi9-minimal@sha256:b9b10f42d7eba7ad4a6d5ef26b7d34fdc892b2ffe59b8d0372ec884008569eb6
 
 WORKDIR /
 

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o /tmp/openshift-builds-shared-resource ./cmd/csidriver
 
-FROM registry.redhat.io/ubi9-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23
+FROM registry.redhat.io/ubi9-minimal@sha256:b9b10f42d7eba7ad4a6d5ef26b7d34fdc892b2ffe59b8d0372ec884008569eb6
 
 RUN \
   microdnf --assumeyes --nodocs install util-linux && \

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:180d433d97773ac90384662ee0f54c3b474f6eeb7219e414a4ca323d1196bb13 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -8,7 +8,7 @@ RUN rm -f /vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml
 
 RUN CGO_ENABLED=1 GO111MODULE=on go build -a -mod=vendor -buildvcs=false -ldflags="-s -w" -tags="strictfipsruntime" -o /tmp/openshift-builds-shared-resource ./cmd/csidriver
 
-FROM registry.redhat.io/ubi9-minimal@sha256:f225a0f8eb7d258011e1f7c8b025dc7dd155d6ffc66c17cd203dcec88935b455
+FROM registry.redhat.io/ubi9-minimal@sha256:8d0a8fb39ec907e8ca62cdd24b62a63ca49a30fe465798a360741fde58437a23
 
 RUN \
   microdnf --assumeyes --nodocs install util-linux && \
@@ -24,7 +24,7 @@ ENTRYPOINT ["./openshift-builds-shared-resource"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource" \
-	cpe="cpe:/a:redhat:openshift_builds:1.7::el9" \
+	cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
 	distribution-scope="public" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
@@ -36,4 +36,4 @@ LABEL \
 	summary="Red Hat OpenShift Builds Shared Resource" \
 	url="https://github.com/openshift/csi-driver-shared-resource" \
 	vendor="Red Hat, Inc." \
-	version="v1.7.0"
+	version="v1.8.0"


### PR DESCRIPTION
## Summary
- Updated go-toolset and ubi9-minimal base images to latest
- Updated version and cpe labels for 1.8 release

**Next step:** After this PR merges, run `/feature-csi-branch` to cut the builds-1.8 branch.

Assisted-By: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base container images for shared-resource-webhook and shared-resource components to newer runtime and build images.
  * Bumped component version from v1.7.0 to v1.8.0.
  * Updated build metadata (platform/CPE) to align with current platform standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->