### PR TITLE
[BUILD-2065] add workflow to create release branches

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -1,0 +1,41 @@
+name: Create Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.8)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Version must be in X.Y format (e.g., 1.8)"
+            exit 1
+          fi
+
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Check branch does not exist
+        run: |
+          if git ls-remote --heads origin "builds-${{ inputs.version }}" | grep -q "builds-${{ inputs.version }}"; then
+            echo "ERROR: Branch builds-${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Create and push release branch
+        run: |
+          git checkout -b "builds-${{ inputs.version }}"
+          git push origin "builds-${{ inputs.version }}"
+          echo "Created and pushed builds-${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- Adds a GitHub Action to create builds-X.Y release branches from master
- Triggered via workflow_dispatch with version input (e.g., 1.8)
- Validates version format and checks branch doesn't already exist

Assisted-By: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow for streamlined internal release branch creation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->