### PR TITLE
builds-1.8: update go-toolset base image to latest

### DIFF
--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:2c17ce45c735ad308240139d807eeb22f4499fd90e883634ba5a191779f1ff94 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset@sha256:2c17ce45c735ad308240139d807eeb22f4499fd90e883634ba5a191779f1ff94 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:e06a6f4c85c3ca75f64127542449c9770fb885adfb592f987c576d268ac108de AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 


### PR DESCRIPTION
## Summary

Updates go-toolset base image SHA to latest (1.25.9-1778604137, pushed 2026-05-12).

- `go-toolset`: `2c17ce45...` → `e06a6f4c...`

Co-Authored-By: Claude Opus 4.6