### PR TITLE
fix(tekton): enable package registry proxy for prefetch-dependencies task

### DIFF
--- a/.tekton/openshift-builds-shared-resource-pull-request.yaml
+++ b/.tekton/openshift-builds-shared-resource-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
+  - name: enable-package-registry-proxy
+    value: "true"
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"},{"type": "rpm"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-shared-resource-push.yaml
+++ b/.tekton/openshift-builds-shared-resource-push.yaml
@@ -42,6 +42,8 @@ spec:
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
+  - name: enable-package-registry-proxy
+    value: "true"
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"},{"type": "rpm"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-shared-resource-webhook-pull-request.yaml
+++ b/.tekton/openshift-builds-shared-resource-webhook-pull-request.yaml
@@ -40,6 +40,8 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
+  - name: enable-package-registry-proxy
+    value: "true"
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineRef:

--- a/.tekton/openshift-builds-shared-resource-webhook-push.yaml
+++ b/.tekton/openshift-builds-shared-resource-webhook-push.yaml
@@ -40,6 +40,8 @@ spec:
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
+  - name: enable-package-registry-proxy
+    value: "true"
   - name: prefetch-input
     value: '{"packages": [{"type": "gomod"}]}'
   pipelineRef:


### PR DESCRIPTION
Set enable-package-registry-proxy to true in the prefetch-dependencies-oci-ta task for both the shared-resource and shared-resource-webhook components. This resolves the Conforma policy violation
prefetch_dependencies.package_registry_proxy_enabled (effective 2026-05-13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled package registry proxy functionality across all build pipeline configurations to optimize package registry access during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->