### PR TITLE
[BUILD-2062] Update CSI driver image labels to el10

### DIFF
--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -19,7 +19,7 @@ ENTRYPOINT ["./openshift-builds-shared-resource-webhook"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource-webhook" \
-	cpe="cpe:/a:redhat:openshift_builds:1.8::el10" \
+	cpe="cpe:/a:redhat:openshift_builds:1.9::el10" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
 	distribution-scope="public" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
@@ -31,4 +31,4 @@ LABEL \
 	summary="Red Hat OpenShift Builds Shared Resource Webhook" \
 	url="https://github.com/openshift/csi-driver-shared-resource" \
 	vendor="Red Hat, Inc." \
-	version="v1.8.0"
+	version="v1.9.0"

--- a/.konflux/shared-resource-webhook/Dockerfile
+++ b/.konflux/shared-resource-webhook/Dockerfile
@@ -19,7 +19,7 @@ ENTRYPOINT ["./openshift-builds-shared-resource-webhook"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource-webhook" \
-	cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
+	cpe="cpe:/a:redhat:openshift_builds:1.8::el10" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \
 	distribution-scope="public" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource Webhook" \

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT ["./openshift-builds-shared-resource"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource" \
-	cpe="cpe:/a:redhat:openshift_builds:1.8::el10" \
+	cpe="cpe:/a:redhat:openshift_builds:1.9::el10" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
 	distribution-scope="public" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
@@ -36,4 +36,4 @@ LABEL \
 	summary="Red Hat OpenShift Builds Shared Resource" \
 	url="https://github.com/openshift/csi-driver-shared-resource" \
 	vendor="Red Hat, Inc." \
-	version="v1.8.0"
+	version="v1.9.0"

--- a/.konflux/shared-resource/Dockerfile
+++ b/.konflux/shared-resource/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT ["./openshift-builds-shared-resource"]
 
 LABEL \
 	com.redhat.component="openshift-builds-shared-resource" \
-	cpe="cpe:/a:redhat:openshift_builds:1.8::el9" \
+	cpe="cpe:/a:redhat:openshift_builds:1.8::el10" \
 	description="Red Hat OpenShift Builds CSI Driver Shared Resource" \
 	distribution-scope="public" \
 	io.k8s.description="Red Hat OpenShift Builds CSI Driver Shared Resource" \


### PR DESCRIPTION
Update Dockerfile CPE and image name labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image metadata to version 1.9.0 and the EL10 compatibility target.
  * Applied the metadata updates to both shared resource images; no runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->