### PR TITLE
[BUILD-1841] feat(csi-driver): add TLS flag support and ML-KEM curves

### DIFF
--- a/cmd/csidriver/main.go
+++ b/cmd/csidriver/main.go
@@ -32,6 +32,8 @@ var (
 	driverName        string // name of the CSI driver, registered in the cluster
 	nodeID            string // current Kubernetes node identifier
 	maxVolumesPerNode int64  // maximum amount of volumes per node, i.e. per driver instance
+	tlsMinVersion     string // minimum TLS version for metrics server
+	tlsCipherSuites   string // comma-separated TLS cipher suites for metrics server
 
 )
 
@@ -46,7 +48,7 @@ var rootCmd = &cobra.Command{
 		cfgManager := config.NewManager(cfgFilePath)
 		cfg, err := cfgManager.LoadConfig()
 		if err != nil {
-			fmt.Printf("Failed to load configuration file '%s': %s", cfgFilePath, err.Error())
+			fmt.Printf("Failed to load configuration file '%s': %s\n", cfgFilePath, err.Error())
 			os.Exit(1)
 		}
 
@@ -55,13 +57,13 @@ var rootCmd = &cobra.Command{
 
 		}
 		if kubeClient, err := loadKubernetesClientset(); err != nil {
-			fmt.Printf("Failed to load Kubernetes API client: %s", err.Error())
+			fmt.Printf("Failed to load Kubernetes API client: %s\n", err.Error())
 			os.Exit(1)
 		} else {
 			client.SetClient(kubeClient)
 		}
 		if shareClient, err := loadSharedresourceClientset(); err != nil {
-			fmt.Printf("Failed to load SharedResource API client: %s", err.Error())
+			fmt.Printf("Failed to load SharedResource API client: %s\n", err.Error())
 			os.Exit(1)
 		} else {
 			client.SetShareClient(shareClient)
@@ -78,13 +80,13 @@ var rootCmd = &cobra.Command{
 			mount.New(""),
 		)
 		if err != nil {
-			fmt.Printf("Failed to initialize driver: %s", err.Error())
+			fmt.Printf("Failed to initialize driver: %s\n", err.Error())
 			os.Exit(1)
 		}
 
-		c, err := controller.NewController(cfg.GetShareRelistInterval(), cfg.RefreshResources)
+		c, err := controller.NewController(cfg.GetShareRelistInterval(), cfg.RefreshResources, tlsMinVersion, tlsCipherSuites)
 		if err != nil {
-			fmt.Printf("Failed to set up controller: %s", err.Error())
+			fmt.Printf("Failed to set up controller: %s\n", err.Error())
 			os.Exit(1)
 		}
 		prunerTicker := time.NewTicker(cfg.GetShareRelistInterval())
@@ -133,6 +135,8 @@ func init() {
 	rootCmd.Flags().StringVar(&driverName, "drivername", string(operatorv1.SharedResourcesCSIDriver), "name of the driver")
 	rootCmd.Flags().StringVar(&nodeID, "nodeid", "", "node id")
 	rootCmd.Flags().Int64Var(&maxVolumesPerNode, "maxvolumespernode", 0, "limit of volumes per node")
+	rootCmd.Flags().StringVar(&tlsMinVersion, "tls-min-version", "", "Minimum TLS version for metrics server (e.g., VersionTLS12)")
+	rootCmd.Flags().StringVar(&tlsCipherSuites, "tls-cipher-suites", "", "Comma-separated list of cipher suites for metrics server")
 }
 
 // loadKubernetesClientset instantiate a clientset using local config.
@@ -157,7 +161,7 @@ func loadSharedresourceClientset() (sharev1clientset.Interface, error) {
 func runOperator(c *controller.Controller, stopCh <-chan struct{}) {
 	err := c.Run(stopCh)
 	if err != nil {
-		fmt.Printf("Controller exited: %s", err.Error())
+		fmt.Printf("Controller exited: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/csi-driver-shared-resource/pkg/config"
+	tlsprofile "github.com/openshift/csi-driver-shared-resource/pkg/tls"
 	"github.com/openshift/csi-driver-shared-resource/pkg/webhook/csidriver"
 	"github.com/openshift/csi-driver-shared-resource/pkg/webhook/dispatcher"
 )
@@ -23,13 +25,15 @@ const (
 )
 
 var (
-	useTLS        bool
-	tlsCert       string
-	tlsKey        string
-	caCert        string
-	listenAddress string
-	listenPort    int
-	testHooks     bool
+	useTLS          bool
+	tlsCert         string
+	tlsKey          string
+	caCert          string
+	listenAddress   string
+	listenPort      int
+	testHooks       bool
+	tlsMinVersion   string
+	tlsCipherSuites string
 )
 
 var (
@@ -53,6 +57,8 @@ func init() {
 	CmdWebhook.Flags().StringVar(&listenAddress, "listen", "0.0.0.0", "Listen address")
 	CmdWebhook.Flags().IntVar(&listenPort, "port", 5000, "Secure port that the webhook listens on")
 	CmdWebhook.Flags().BoolVar(&testHooks, "testHooks", false, "Test webhook URI uniqueness and quit")
+	CmdWebhook.Flags().StringVar(&tlsMinVersion, "tls-min-version", "", "Minimum TLS version (e.g., VersionTLS12)")
+	CmdWebhook.Flags().StringVar(&tlsCipherSuites, "tls-cipher-suites", "", "Comma-separated list of cipher suites")
 }
 
 func startServer() {
@@ -63,11 +69,14 @@ func startServer() {
 	if testHooks {
 		os.Exit(0)
 	} else {
-		fmt.Printf("HTTP server running at: %s", net.JoinHostPort(listenAddress, strconv.Itoa(listenPort)))
+		fmt.Printf("HTTP server running at: %s\n", net.JoinHostPort(listenAddress, strconv.Itoa(listenPort)))
 	}
 
 	server := &http.Server{
-		Addr: net.JoinHostPort(listenAddress, strconv.Itoa(listenPort)),
+		Addr:         net.JoinHostPort(listenAddress, strconv.Itoa(listenPort)),
+		ReadTimeout:  30 * time.Second, // Kubernetes webhook timeout is 30s
+		WriteTimeout: 30 * time.Second, // Allow time for admission response
+		IdleTimeout:  120 * time.Second,
 	}
 	//TODO do we want to explore signal handling / graceful shutdown for the webhook, with some wrapper around the http server
 	var err error
@@ -75,21 +84,32 @@ func startServer() {
 		var cafile []byte
 		cafile, err = os.ReadFile(caCert)
 		if err != nil {
-			fmt.Printf("Couldn't read CA cert file: %s", err.Error())
+			fmt.Printf("Couldn't read CA cert file: %s\n", err.Error())
 			os.Exit(1)
 		}
 		certpool := x509.NewCertPool()
-		certpool.AppendCertsFromPEM(cafile)
-
-		server.TLSConfig = &tls.Config{
-			RootCAs: certpool,
+		if !certpool.AppendCertsFromPEM(cafile) {
+			fmt.Printf("Failed to parse CA certificate from %s\n", caCert)
+			os.Exit(1)
 		}
+
+		// Build TLS config from flags injected by operator
+		tlsCfg, err := tlsprofile.BuildTLSConfigFromFlags(tlsMinVersion, tlsCipherSuites)
+		if err != nil {
+			fmt.Printf("Invalid TLS configuration: %s\n", err.Error())
+			os.Exit(1)
+		}
+		tlsCfg.ClientCAs = certpool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+
+		server.TLSConfig = tlsCfg
+
 		err = server.ListenAndServeTLS(tlsCert, tlsKey)
 	} else {
 		err = server.ListenAndServe()
 	}
 	if err != nil {
-		fmt.Printf("Error serving connection: %s", err.Error())
+		fmt.Printf("Error serving connection: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"crypto/tls"
 	"fmt"
 	"sync"
 	"time"
@@ -19,6 +20,7 @@ import (
 	objcache "github.com/openshift/csi-driver-shared-resource/pkg/cache"
 	"github.com/openshift/csi-driver-shared-resource/pkg/client"
 	"github.com/openshift/csi-driver-shared-resource/pkg/metrics"
+	tlsprofile "github.com/openshift/csi-driver-shared-resource/pkg/tls"
 )
 
 const (
@@ -50,13 +52,16 @@ type Controller struct {
 
 	listers *client.Listers
 
+	tlsMinVersion   string
+	tlsCipherSuites string
+
 	refreshResources bool
 }
 
 // NewController instantiate a new controller with relisting interval, and optional refresh-resources
 // mode. Refresh-resources mode means the controller will keep watching for ConfigMaps and Secrets
 // for future changes, when disabled it only loads the resource contents before mounting the volume.
-func NewController(shareRelist time.Duration, refreshResources bool) (*Controller, error) {
+func NewController(shareRelist time.Duration, refreshResources bool, tlsMinVersion string, tlsCipherSuites string) (*Controller, error) {
 	kubeClient := client.GetClient()
 	shareClient := client.GetShareClient()
 
@@ -78,6 +83,8 @@ func NewController(shareRelist time.Duration, refreshResources bool) (*Controlle
 		sharedSecretInformer:           shareInformerFactory.Sharedresource().V1alpha1().SharedSecrets().Informer(),
 		listers:                        client.GetListers(),
 		refreshResources:               refreshResources,
+		tlsMinVersion:                  tlsMinVersion,
+		tlsCipherSuites:                tlsCipherSuites,
 	}
 
 	c.cfgMapWorkqueue = workqueue.NewNamedRateLimitingQueue(
@@ -116,7 +123,11 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 
 	// start the Prometheus metrics serner
 	klog.Info("Starting the metrics server")
-	server, err := metrics.BuildServer(metrics.MetricsPort)
+	metricsTLSCfg, err := c.buildMetricsTLSConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build metrics TLS config: %w", err)
+	}
+	server, err := metrics.BuildServer(metrics.MetricsPort, metricsTLSCfg)
 	if err != nil {
 		return err
 	}
@@ -627,4 +638,10 @@ func (c *Controller) syncSharedSecret(event client.Event) error {
 	}
 
 	return err
+}
+
+// buildMetricsTLSConfig builds TLS configuration from flags injected by the operator.
+// Returns an error if the TLS configuration flags are invalid.
+func (c *Controller) buildMetricsTLSConfig() (*tls.Config, error) {
+	return tlsprofile.BuildTLSConfigFromFlags(c.tlsMinVersion, c.tlsCipherSuites)
 }

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -21,7 +22,7 @@ var (
 )
 
 // BuildServer creates the http.Server struct
-func BuildServer(port int) (*http.Server, error) {
+func BuildServer(port int, tlsCfg *tls.Config) (*http.Server, error) {
 	if port <= 0 {
 		klog.Error("invalid port for metric server")
 		return nil, errors.New("invalid port for metrics server")
@@ -31,8 +32,12 @@ func BuildServer(port int) (*http.Server, error) {
 	router := http.NewServeMux()
 	router.Handle("/metrics", promhttp.Handler())
 	srv := &http.Server{
-		Addr:    bindAddr,
-		Handler: router,
+		Addr:         bindAddr,
+		Handler:      router,
+		TLSConfig:    tlsCfg,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
 	return srv, nil
@@ -56,7 +61,5 @@ func RunServer(srv *http.Server, stopCh <-chan struct{}) {
 		}
 	}()
 	<-stopCh
-	if err := srv.Close(); err != nil {
-		klog.Errorf("error closing metrics server: %v", err)
-	}
+	StopServer(srv)
 }

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -66,20 +66,24 @@ func generateTempCertificates() (string, string, error) {
 		return "", "", err
 	}
 	defer cert.Close()
-	pem.Encode(cert, &pem.Block{
+	if err := pem.Encode(cert, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: derBytes,
-	})
+	}); err != nil {
+		return "", "", err
+	}
 
 	keyPath, err := os.CreateTemp("", "testkey-")
 	if err != nil {
 		return "", "", err
 	}
 	defer keyPath.Close()
-	pem.Encode(keyPath, &pem.Block{
+	if err := pem.Encode(keyPath, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
+	}); err != nil {
+		return "", "", err
+	}
 
 	return keyPath.Name(), cert.Name(), nil
 }
@@ -109,7 +113,7 @@ func runMetricsServer(t *testing.T) (int, chan<- struct{}) {
 	var port int = MetricsPort + int(atomic.AddUint32(&portOffset, 1))
 
 	ch := make(chan struct{})
-	server, err := BuildServer(port)
+	server, err := BuildServer(port, nil)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/pkg/tls/profile.go
+++ b/pkg/tls/profile.go
@@ -1,0 +1,91 @@
+package tls
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// parseTLSVersion converts TLS version strings to crypto/tls constants.
+func parseTLSVersion(v string) (uint16, error) {
+	versions := map[string]uint16{
+		"VersionTLS10": tls.VersionTLS10,
+		"VersionTLS11": tls.VersionTLS11,
+		"VersionTLS12": tls.VersionTLS12,
+		"VersionTLS13": tls.VersionTLS13,
+	}
+	if ver, ok := versions[v]; ok {
+		return ver, nil
+	}
+	return 0, fmt.Errorf("unknown TLS version: %s", v)
+}
+
+// mapCipherSuites converts OpenSSL-style cipher names (used in OpenShift TLS
+// profiles) to Go crypto/tls constants. Ciphers without a Go constant are
+// silently skipped.
+func mapCipherSuites(names []string) []uint16 {
+	// OpenSSL to Go cipher suite name mapping
+	// Only includes modern cipher suites with strong integrity (SHA256+) and encryption.
+	// SHA-1 and 3DES cipher suites are excluded for security compliance.
+	m := map[string]uint16{
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	}
+
+	out := make([]uint16, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if id, ok := m[name]; ok {
+			out = append(out, id)
+		} else {
+			klog.V(4).Infof("Cipher suite %q not supported by Go, skipping", name)
+		}
+	}
+	return out
+}
+
+// BuildTLSConfigFromFlags builds a tls.Config from TLS version and cipher suite flags.
+// These flags are injected by the operator based on the cluster TLS profile.
+// The returned config has MinVersion and CipherSuites set. CurvePreferences is
+// left unset so Go defaults (including ML-KEM) apply.
+// Returns an error if non-empty flags contain invalid values that cannot be applied.
+func BuildTLSConfigFromFlags(minVersionFlag string, cipherSuitesFlag string) (*tls.Config, error) {
+	cfg := &tls.Config{}
+
+	// Parse minimum TLS version
+	if minVersionFlag != "" {
+		minVer, err := parseTLSVersion(minVersionFlag)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS version %q: %w", minVersionFlag, err)
+		}
+		cfg.MinVersion = minVer
+	} else {
+		// Safe default when not configured
+		cfg.MinVersion = tls.VersionTLS12
+	}
+
+	// Only set cipher suites for TLS 1.2 and below; Go hardcodes TLS 1.3 ciphers
+	if cfg.MinVersion < tls.VersionTLS13 && cipherSuitesFlag != "" {
+		cipherNames := strings.Split(cipherSuitesFlag, ",")
+		suites := mapCipherSuites(cipherNames)
+		if len(suites) == 0 {
+			// All cipher suites were invalid - fail fast to prevent security policy violation
+			return nil, fmt.Errorf("no valid cipher suites found in %q", cipherSuitesFlag)
+		}
+		cfg.CipherSuites = suites
+	}
+
+	// CurvePreferences intentionally left unset to enable ML-KEM support (Go 1.23+)
+	return cfg, nil
+}

--- a/pkg/tls/profile_test.go
+++ b/pkg/tls/profile_test.go
@@ -1,0 +1,412 @@
+package tls
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	cryptotls "crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestBuildTLSConfigFromFlags(t *testing.T) {
+	tests := []struct {
+		name                string
+		minVersionFlag      string
+		cipherSuitesFlag    string
+		wantMinVersion      uint16
+		wantCipherSuites    []uint16
+		wantCipherSuitesNil bool
+		wantErr             bool
+	}{
+		{
+			name:                "empty flags defaults to TLS 1.2",
+			minVersionFlag:      "",
+			cipherSuitesFlag:    "",
+			wantMinVersion:      cryptotls.VersionTLS12,
+			wantCipherSuitesNil: true,
+		},
+		{
+			name:             "TLS 1.2 with cipher suites",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256",
+			wantMinVersion:   cryptotls.VersionTLS12,
+			wantCipherSuites: []uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, cryptotls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		},
+		{
+			name:                "TLS 1.3 ignores cipher suites",
+			minVersionFlag:      "VersionTLS13",
+			cipherSuitesFlag:    "ECDHE-RSA-AES128-GCM-SHA256",
+			wantMinVersion:      cryptotls.VersionTLS13,
+			wantCipherSuitesNil: true,
+		},
+		{
+			name:                "TLS 1.0",
+			minVersionFlag:      "VersionTLS10",
+			cipherSuitesFlag:    "",
+			wantMinVersion:      cryptotls.VersionTLS10,
+			wantCipherSuitesNil: true,
+		},
+		{
+			name:                "TLS 1.1",
+			minVersionFlag:      "VersionTLS11",
+			cipherSuitesFlag:    "",
+			wantMinVersion:      cryptotls.VersionTLS11,
+			wantCipherSuitesNil: true,
+		},
+		{
+			name:             "unknown version returns error",
+			minVersionFlag:   "VersionTLS99",
+			cipherSuitesFlag: "",
+			wantErr:          true,
+		},
+		{
+			name:             "multiple cipher suites with spaces",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "ECDHE-RSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-CHACHA20-POLY1305",
+			wantMinVersion:   cryptotls.VersionTLS12,
+			wantCipherSuites: []uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, cryptotls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, cryptotls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+		},
+		{
+			name:             "unsupported cipher suites are skipped",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "ECDHE-RSA-AES128-GCM-SHA256,UNSUPPORTED-CIPHER,ECDHE-ECDSA-AES128-GCM-SHA256",
+			wantMinVersion:   cryptotls.VersionTLS12,
+			wantCipherSuites: []uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, cryptotls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		},
+		{
+			name:             "all invalid cipher suites returns error",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "INVALID-CIPHER-1,INVALID-CIPHER-2",
+			wantErr:          true,
+		},
+		{
+			name:             "weak SHA-1 cipher suites are rejected with error",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "ECDHE-RSA-AES128-SHA,ECDHE-ECDSA-AES128-SHA,AES128-SHA,AES256-SHA",
+			wantErr:          true,
+		},
+		{
+			name:             "3DES cipher suite is rejected with error",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "DES-CBC3-SHA",
+			wantErr:          true,
+		},
+		{
+			name:             "weak ciphers mixed with strong ciphers only accepts strong",
+			minVersionFlag:   "VersionTLS12",
+			cipherSuitesFlag: "ECDHE-RSA-AES128-SHA,ECDHE-RSA-AES128-GCM-SHA256,DES-CBC3-SHA,ECDHE-ECDSA-AES128-GCM-SHA256",
+			wantMinVersion:   cryptotls.VersionTLS12,
+			wantCipherSuites: []uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, cryptotls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := BuildTLSConfigFromFlags(tt.minVersionFlag, tt.cipherSuitesFlag)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if cfg.MinVersion != tt.wantMinVersion {
+				t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tt.wantMinVersion)
+			}
+
+			if tt.wantCipherSuitesNil {
+				if cfg.CipherSuites != nil {
+					t.Errorf("CipherSuites = %v, want nil", cfg.CipherSuites)
+				}
+			} else {
+				if !cipherSuitesEqual(cfg.CipherSuites, tt.wantCipherSuites) {
+					t.Errorf("CipherSuites = %v, want %v", cfg.CipherSuites, tt.wantCipherSuites)
+				}
+			}
+
+			// CurvePreferences should always be unset (for ML-KEM support)
+			if cfg.CurvePreferences != nil {
+				t.Errorf("CurvePreferences = %v, want nil (for ML-KEM support)", cfg.CurvePreferences)
+			}
+		})
+	}
+}
+
+func cipherSuitesEqual(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestTLSHandshakeWithFlags(t *testing.T) {
+	// Test that TLS config built from flags actually works in a real handshake
+	minVersionFlag := "VersionTLS12"
+	cipherSuitesFlag := "ECDHE-RSA-AES128-GCM-SHA256"
+
+	cert, certPEM, keyPEM := generateTestCert(t)
+
+	serverCfg, err := BuildTLSConfigFromFlags(minVersionFlag, cipherSuitesFlag)
+	if err != nil {
+		t.Fatalf("Failed to build server TLS config: %v", err)
+	}
+	serverCfg.MaxVersion = cryptotls.VersionTLS12 // Force TLS 1.2 to test cipher suite negotiation
+	serverCert, err := cryptotls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("Failed to create server cert: %v", err)
+	}
+	serverCfg.Certificates = []cryptotls.Certificate{serverCert}
+
+	clientCfg, err := BuildTLSConfigFromFlags(minVersionFlag, cipherSuitesFlag)
+	if err != nil {
+		t.Fatalf("Failed to build client TLS config: %v", err)
+	}
+	clientCfg.MaxVersion = cryptotls.VersionTLS12 // Force TLS 1.2 to test cipher suite negotiation
+	certPool := x509.NewCertPool()
+	certPool.AddCert(cert)
+	clientCfg.RootCAs = certPool
+	clientCfg.ServerName = "localhost"
+
+	// Test handshake
+	listener, err := cryptotls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Errorf("Failed to close listener: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() {
+			if err := conn.Close(); err != nil {
+				t.Errorf("Failed to close server connection: %v", err)
+			}
+		}()
+
+		// Perform TLS handshake on server side with context
+		tlsConn, ok := conn.(*cryptotls.Conn)
+		if !ok {
+			serverDone <- nil
+			return
+		}
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- nil
+	}()
+
+	dialer := &cryptotls.Dialer{Config: clientCfg}
+	conn, err := dialer.DialContext(ctx, "tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Client handshake failed: %v", err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("Failed to close client connection: %v", err)
+		}
+	}()
+
+	// Verify client handshake completed
+	tlsConn, ok := conn.(*cryptotls.Conn)
+	if !ok {
+		t.Fatal("Expected *tls.Conn from dialer")
+	}
+	state := tlsConn.ConnectionState()
+	if !state.HandshakeComplete {
+		t.Fatal("Client handshake not complete")
+	}
+
+	// Verify TLS 1.2 was negotiated
+	if state.Version != cryptotls.VersionTLS12 {
+		t.Errorf("Expected TLS 1.2, got version 0x%x", state.Version)
+	}
+
+	// Verify the expected cipher suite was negotiated
+	if state.CipherSuite != cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+		t.Errorf("Expected cipher suite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, got 0x%x", state.CipherSuite)
+	}
+
+	// Wait for server
+	if err := <-serverDone; err != nil {
+		t.Fatalf("Server handshake failed: %v", err)
+	}
+}
+
+func TestTLSHandshakeWithTLS13(t *testing.T) {
+	// Test TLS 1.3 negotiation to verify ML-KEM readiness (CurvePreferences left unset)
+	minVersionFlag := "VersionTLS13"
+	cipherSuitesFlag := "" // TLS 1.3 ignores cipher suites
+
+	cert, certPEM, keyPEM := generateTestCert(t)
+
+	serverCfg, err := BuildTLSConfigFromFlags(minVersionFlag, cipherSuitesFlag)
+	if err != nil {
+		t.Fatalf("Failed to build server TLS config: %v", err)
+	}
+	serverCert, err := cryptotls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("Failed to create server cert: %v", err)
+	}
+	serverCfg.Certificates = []cryptotls.Certificate{serverCert}
+
+	clientCfg, err := BuildTLSConfigFromFlags(minVersionFlag, cipherSuitesFlag)
+	if err != nil {
+		t.Fatalf("Failed to build client TLS config: %v", err)
+	}
+	certPool := x509.NewCertPool()
+	certPool.AddCert(cert)
+	clientCfg.RootCAs = certPool
+	clientCfg.ServerName = "localhost"
+
+	// Test handshake
+	listener, err := cryptotls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Errorf("Failed to close listener: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() {
+			if err := conn.Close(); err != nil {
+				t.Errorf("Failed to close server connection: %v", err)
+			}
+		}()
+
+		tlsConn, ok := conn.(*cryptotls.Conn)
+		if !ok {
+			serverDone <- nil
+			return
+		}
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- nil
+	}()
+
+	dialer := &cryptotls.Dialer{Config: clientCfg}
+	conn, err := dialer.DialContext(ctx, "tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Client handshake failed: %v", err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("Failed to close client connection: %v", err)
+		}
+	}()
+
+	// Verify client handshake completed
+	tlsConn, ok := conn.(*cryptotls.Conn)
+	if !ok {
+		t.Fatal("Expected *tls.Conn from dialer")
+	}
+	state := tlsConn.ConnectionState()
+	if !state.HandshakeComplete {
+		t.Fatal("Client handshake not complete")
+	}
+
+	// Verify TLS 1.3 was negotiated
+	if state.Version != cryptotls.VersionTLS13 {
+		t.Errorf("Expected TLS 1.3, got version 0x%x", state.Version)
+	}
+
+	// Verify CurvePreferences was left unset (ML-KEM readiness)
+	if serverCfg.CurvePreferences != nil {
+		t.Errorf("Server CurvePreferences should be nil for ML-KEM support, got %v", serverCfg.CurvePreferences)
+	}
+	if clientCfg.CurvePreferences != nil {
+		t.Errorf("Client CurvePreferences should be nil for ML-KEM support, got %v", clientCfg.CurvePreferences)
+	}
+
+	// Wait for server
+	if err := <-serverDone; err != nil {
+		t.Fatalf("Server handshake failed: %v", err)
+	}
+}
+
+func generateTestCert(t *testing.T) (*x509.Certificate, []byte, []byte) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("Failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	keyDER := x509.MarshalPKCS1PrivateKey(priv)
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyDER,
+	})
+
+	return cert, certPEM, keyPEM
+}


### PR DESCRIPTION
Accept --tls-min-version and --tls-cipher-suites flags for webhook and metrics servers to enable cluster TLS profile adherence by the operator. Leave CurvePreferences unset to enable ML-KEM post-quantum cryptography support (Go 1.23+).

Changes:
- Add TLS flags to webhook and CSI driver
- Build tls.Config from flags
- Leave CurvePreferences unset for ML-KEM-768 support
- Add tests including TLS handshake validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS minimum versions and cipher suites for metrics and webhook HTTPS servers.
  * Added command-line flags for TLS settings.
  * TLS defaults to version 1.2 when no minimum version is specified.
  * Webhook HTTPS now supports configured client certificate validation.
* **Security**
  * Invalid TLS versions or cipher-suite lists now prevent startup with an error.
  * Unsupported cipher suites are skipped when valid alternatives are provided.
  * TLS 1.3 uses Go’s built-in cipher selection and curve preferences.
* **Reliability**
  * Added HTTP server timeouts and graceful metrics server shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->